### PR TITLE
docs: förtydliga AI-instruktioner med parentesförklaringar och plattformssteg

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,12 @@ Detta dokument styr hur AI-agenten ska jobba i detta repo för att hjälpa en no
 ## 1) Kommunikationsstil
 - Skriv på enkel svenska.
 - Undvik fackspråk om det inte behövs.
+- När tekniska termer används i svar, beskrivningar eller instruktioner till användaren: lägg alltid en kort förklaring/synonym i parentes direkt efter termen.
+  - Exempel: "deploy (publicera till webben)", "repo (projektmapp på GitHub)".
+- Anpassa instruktionerna till plattformen där användaren jobbar:
+  - Codex (webb): förklara var i chatten/verktyget användaren klickar eller klistrar in.
+  - GitHub (webb): förklara exakta knappar/flikar (t.ex. Branches, Pull requests, Settings).
+  - Netlify (webb): förklara exakta steg i UI (t.ex. Add new site, Deploys, Site settings).
 - Ge alltid copy/paste-kommandon.
 - Berätta **var** kommandot ska köras (repo-rot, undermapp, Netlify UI osv).
 - Avsluta alltid med: "Nästa enklaste steg för dig är ..."

--- a/README.md
+++ b/README.md
@@ -32,11 +32,13 @@ Det här dokumentet är skrivet för dig som vill **bygga, testa och publicera a
 
 ### Pågående aktivitet (nu)
 - Dokumentation och workflow-optimering för enkel utveckling + deploy.
+- Lagt till språkregel: tekniska termer får parentesförklaring + plattformsanpassade instruktioner (Codex webb, GitHub webb, Netlify webb).
 
 ### Kvar att göra
 - Koppla egen Netlify-site till repo.
 - Lägga till enkel validering/check-script i `package.json`.
 - Publicera första live-version och verifiera länk.
+- Fortsätt använda parentesförklaringar för tekniska ord i all användarnära dokumentation.
 
 ---
 
@@ -147,3 +149,22 @@ Detta gör att du alltid vet:
 - vad som gjorts,
 - vad som kör just nu,
 - vad nästa steg är.
+
+
+## 9) Nya språkregler för AI-svar (viktigt)
+
+För att göra allt ännu mer noob-vänligt gäller följande när AI-agenten hjälper dig:
+
+1. Tekniska ord ska alltid följas av en enkel parentes-förklaring.
+   - Exempel: `deploy (publicera till webben)`
+   - Exempel: `commit (spara en versionspunkt i Git)`
+   - Exempel: `pull request/PR (förslag på ändringar i GitHub)`
+
+2. Instruktioner ska anpassas efter var du jobbar:
+   - **Codex (webb):** AI ska skriva exakt vad du gör i chatten/webbgränssnittet.
+   - **GitHub (webb):** AI ska nämna rätt flikar/knappar i GitHub-webben.
+   - **Netlify (webb):** AI ska ge tydliga UI-steg för deploy/publicering.
+
+3. Om ett terminalkommando behövs ska AI alltid skriva:
+   - exakt copy/paste-kommando,
+   - var det körs (repo-rot, undermapp, eller i Netlify/GitHub UI).

--- a/panikknappen_projektoversikt_v_1.md
+++ b/panikknappen_projektoversikt_v_1.md
@@ -115,3 +115,6 @@ Guardian Bubble – Version 2.0
 
 Utvecklas vidare.
 
+## Kommunikationsregel för AI (tillägg)
+- AI ska skriva tekniska termer med parentesförklaring, t.ex. `branch (separat arbetsspår i Git)`.
+- AI ska anpassa instruktioner till Codex (webb), GitHub (webb) och Netlify (webb), med tydliga klicksteg i respektive gränssnitt.


### PR DESCRIPTION
### Motivation
- Göra dokumentationen mer noob‑vänlig genom att kräva korta förklaringar/synonymer i parentes efter tekniska termer (så läsaren snabbt förstår betydelsen).
- Se till att AI‑instruktioner alltid anpassas efter var användaren jobbar: Codex (webb), GitHub (webb) och Netlify (webb), så att UI‑steg blir tydliga.

### Description
- Lagt till regel i `AGENTS.md` om att tekniska termer alltid följs av en kort parentesförklaring och om plattformsanpassning (Codex/GitHub/Netlify).
- Uppdaterat `README.md` med statusrad som visar att språkregeln införts och lagt till sektionen `9) Nya språkregler för AI-svar (viktigt)` med konkreta exempel och plattformsanpassning.
- Lagt till motsvarande kort regel i `panikknappen_projektoversikt_v_1.md` för konsekvens i projektöversikten.

### Testing
- Körda automatiska kontroller: `git diff --check` för whitespace/format (lyckades) och filändringsöversikt via `git show --stat --oneline` för verifikation av ändrade filer.
- Repo‑status kontrollerad med `git status --short` för att säkerställa att ändringarna är registrerade.
- Nästa enklaste steg för dig är att öppna PR:n i GitHub (webb), läsa ändringarna och slå ihop dem om allt ser bra ut.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994d6a6de04832891fd65ff4a5dd209)