### PR TITLE
chore: konfigurera Netlify deploy preview för panik-overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,14 @@ Det här dokumentet är skrivet för dig som vill **bygga, testa och publicera a
 ### Pågående aktivitet (nu)
 - Dokumentation och workflow-optimering för enkel utveckling + deploy.
 - Lagt till språkregel: tekniska termer får parentesförklaring + plattformsanpassade instruktioner (Codex webb, GitHub webb, Netlify webb).
+- Konfigurerar Netlify via `netlify.toml` så deploy preview (förhandspublicering) alltid använder `panik-overlay/`.
 
 ### Kvar att göra
 - Koppla egen Netlify-site till repo.
 - Lägga till enkel validering/check-script i `package.json`.
 - Publicera första live-version och verifiera länk.
 - Fortsätt använda parentesförklaringar för tekniska ord i all användarnära dokumentation.
+- Byt ut Netlify-exempellänk i sektion 6 mot din riktiga production URL (publik produktionslänk).
 
 ---
 
@@ -62,6 +64,10 @@ Stoppa servern:
 ## 4) Netlify Deploy – enkel och pålitlig väg
 
 Mål: få en **publik URL** för preview/test.
+
+Repo:t har nu en `netlify.toml` (Netlify konfigurationsfil) i repo-roten som pekar ut:
+- `publish = "panik-overlay"` (mappen som ska publiceras)
+- redirect-regel för `/*` till `/index.html` (gör att sidan laddar rätt även om du öppnar en undersökväg).
 
 ### 4.1 Förberedelser (en gång)
 1. Skapa konto på Netlify.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,10 @@
+[build]
+  publish = "panik-overlay"
+
+[build.environment]
+  NODE_VERSION = "20"
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
### Motivation
- Säkerställa att Netlify Deploy Preview alltid bygger och publicerar rätt mapp (`panik-overlay`) så förhandsvisningar blir pålitliga.
- Göra det enklare för nya användare att följa och använda deploy-flödet genom att dokumentera konfigurationen i `README.md`.

### Description
- Lagt till `netlify.toml` i repo-roten med `publish = "panik-overlay"`, `NODE_VERSION = "20"` och en SPA-redirect från `/*` till `/index.html` så routing fungerar i förhandsvisningar.
- Uppdaterat `README.md` för att notera att Netlify är konfigurerat, förklara vad filen gör och beskriva nästa steg för produktionsdeploy.
- Placeringen av `netlify.toml` gör att Netlify inte behöver gissa publiceringsmapp och ger stabilare deploy previews.

### Testing
- Parserade `netlify.toml` med Python `tomllib` (`python -c`-kontroll) och filen rapporterades giltig.
- Kört `git diff --check` för whitespace/formatkontroll vilket lyckades.
- Verifierat ändrade filer med en kort diff-/stat-kontroll för att säkerställa att `netlify.toml` och `README.md` är med i ändringarna.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994d8b12cbc832880e5f764626158a8)