### PR TITLE
docs: lägg till to-do/funktionskarta och uppdatera README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,16 +30,18 @@ Det här dokumentet är skrivet för dig som vill **bygga, testa och publicera a
 - Netlify-konfiguration (`netlify.toml`) är verifierad med `publish = "panik-overlay"`, Node 20 och redirect för SPA (single page app/en-sides-app).
 - Deploy-test via `npx netlify-cli deploy --dir=panik-overlay` är kört i CI/container och stoppade vid Netlify-login (inloggning) eftersom browser-öppning saknas i miljön.
 - Nytt hjälpscript `scripts/netlify-deploy.sh` finns för preview/prod-deploy (publicering) med samma mappval (`panik-overlay`).
+- Ny to-do/funktionskarta är skapad i `to-do/readme.md` med uppdelning: klart, delvis klart, planerat och arkitekturstatus.
 
 ### Föreslagna nästa aktiviteter
-1. Verifiera iOS-känsla (touch-respons och läsbarhet) på riktig iPhone/iPad.
-2. Bestäm innehåll för fler språk (vilka språk utöver svenska/engelska).
+1. Bekräfta om serverdel ska ligga i samma repo eller separat repo.
+2. Om separat server: dokumentera exakt WS/API-kontrakt i README.
 3. Koppla familjeappens knappar till riktig data/API när backend finns.
 
 ### Pågående aktivitet (nu)
-- Köra verifierad preview deploy (testpublicering) med hjälpscript och dokumentera slutlig live-länk.
+- Synka dokumentation mot full funktionsinventering så teamet har en tydlig nulägesbild.
 
 ### Kvar att göra
+- Lägga tillbaka/ansluta serverkod för full WebSocket- och incidentkedja i detta repo.
 - Lägga till fler språk än svenska/engelska (enligt prioritering).
 - Ersätta mockdata (testdata) i familjeappen med riktig data.
 - Definiera vilka loggfält som ska exporteras/delas utanför browsern.

--- a/to-do/readme.md
+++ b/to-do/readme.md
@@ -1,0 +1,141 @@
+# To-do / Funktionskarta för Panikknappen V2
+
+Det här dokumentet samlar nuläget i en tydlig karta så vi kan jobba vidare utan kaos.
+
+## 1) ✅ Funktioner som HAR funnits i kod
+
+### 🧒 Barn-app: flytande overlay-knapp (flera versioner)
+
+Har funnits i olika varianter (historiskt i projektet):
+- Enkel overlay-version
+- Aura/magisk version
+- WebSocket-version kopplad till server
+- Electron-overlay (desktop)
+
+Funktioner som har funnits:
+- Alltid överst (alwaysOnTop)
+- Transparent bakgrund
+- Ingen ram
+- SkipTaskbar
+- Ej fullscreenbar
+- Klickbar overlay
+- Dragbar knapp
+- Begränsad till skärmkanter
+- Touch + mus-stöd
+- Offset-korrekt drag
+- Text följer knappens position
+
+### 🟢 Håll-in-aktivering
+
+Har funnits:
+- 3 sekunders håll (enkel version)
+- 5 sekunders håll (WebSocket-version)
+- Visuell nedräkning
+- Animation under nedräkning
+- Ljudsignal (beep)
+- Sparkles-effekt
+- Halo-effekt runt knapp
+- Skak-animation
+- Avbryts om man släpper
+- Avbryts om man börjar dra
+
+### 🟢 Låsning och tillstånd
+
+Har funnits:
+- `localStorage`-flagga (`panicActive`)
+- Knapp blir låst efter aktivering
+- Text ändras till "Hjälp är på väg ❤️"
+- Visuell nedtoning (brightness-filter)
+- Automatisk reset via server-polling
+
+### 🟢 Serverkoppling (WebSocket) – stöd som funnits
+
+Funktioner som har funnits i server/WS-versioner:
+- WebSocket-anslutning
+- Auto reconnect
+- `PANIC`
+- `COOLDOWN`
+- `STATUS` broadcast
+- `ALERT` broadcast
+- `RESET` broadcast
+- Incident-objekt med metadata (alias/offenderAlias/platform/ip m.m.)
+- Screenshot-limit per minut
+- Cooldown (15 sek)
+- Låst tillstånd per barn
+- Central state-hantering
+
+### 🟢 Screenshot-hantering (serverstöd)
+
+Funktioner som har funnits:
+- `SCREENSHOT` via WebSocket
+- Base64-lagring i state
+- Max 40/minut
+- Broadcast till föräldraklient
+
+> Notering: Barn-appen skickar inte screenshot fullt ut i alla varianter.
+
+### 🟢 Reset-system
+
+Har funnits:
+- `GET /reset-status`
+- `POST /mark-reset`
+- Polling från barn-app varannan sekund
+- Återställning av knapp + rensning av `localStorage`
+
+---
+
+## 2) 🟡 Funktioner som DELVIS finns
+
+| Funktion | Status |
+| --- | --- |
+| Screenshot från barn | Serverdel klar, barn-app ej komplett i alla versioner |
+| Automatiskt blockera motpart | Metadata finns, global teknisk blockering ej klar |
+| Automeddelande till motpart | Fält finns, inte kopplat till spel/API |
+| Nätverkseffekt (riskzon) | Arkitektur möjlig, ej byggd |
+| Test-läge | Inte implementerat |
+| Föräldra-notiser (push) | Inte byggt (bara WebSocket idag) |
+
+---
+
+## 3) 🔵 Planerade men inte fullt implementerade
+
+- Riktig OS-screenshot via Electron API
+- Pushnotiser
+- Riskzon-system mellan användare
+- Permanent databas
+- Autentisering
+- Separat test-knapp (skilt från skarp panic)
+- Logg-historik i UI
+- Prenumerationssystem
+- Juridisk metadata-säkring
+- AI-riskanalys
+
+---
+
+## 4) 🧠 Arkitektur och tekniska komponenter
+
+Nuvarande repo innehåller tydligt:
+- Overlay-webbapp (`panik-overlay/apps/child/index.html`)
+- Föräldra-UI (design/prototyp) (`panik-overlay/apps/family/index.html`)
+- Electron-shell för overlay (`panik-overlay/main.js`, `panik-overlay/preload.js`)
+- Portal-ingång (`panik-overlay/index.html`)
+
+Serverkod för full WebSocket/incident/reset-flöde verkar inte ligga i denna uppladdade repo just nu.
+Det betyder att serverdelen i denna karta ska ses som "finns i tidigare/annan version" tills filerna finns här.
+
+---
+
+## 5) Arbetsfokus framåt (enkel prioritering)
+
+1. Få en stabil barn-app + deploy (publicering till webben) i nuvarande repo.
+2. Lägga tillbaka eller koppla in serverkod i samma repo.
+3. Koppla föräldra-UI till riktiga realtidsdata.
+4. Bygga säkerhet (auth/databas/loggar) steg för steg.
+
+---
+
+## 6) Nästa konkreta steg
+
+- Bekräfta om server-repot ska läggas in här eller köras separat.
+- Om separat: dokumentera URL + API/WS-kontrakt i README.
+- Om samma repo: lägg in servermapp och koppla barn/föräldraflöde end-to-end.


### PR DESCRIPTION
### Motivation
- Förtydliga projektets nuläge och ge en enkel, nybörjarvänlig funktionskarta så teamet vet vad som är klart, delvis klart och planerat. 
- Undvika missförstånd kring backend genom att tydligt markera att serverdelen (WebSocket, realtids-backend) inte finns incheckad i detta repo.

### Description
- Lagt till `to-do/readme.md` som innehåller en full funktionskarta och arkitekturstatus (klart, delvis, planerat). 
- Uppdaterat `README.md` (projektets huvud-dokument) så statusloggen pekar på nya to-do-filen och så att nästa steg är klarare. 
- Behållit och hänvisat till befintliga deploy-instruktioner (Netlify, publiceringsplattform) och lagt in konkreta alternativ för serverbeslut (WS/API-kontrakt). 
- Ändrade filer: ny fil `to-do/readme.md` och uppdaterad `README.md`.

### Testing
- Körde struktur-check i `panik-overlay` genom att köra `cd panik-overlay && npm run check` (lokal test) och fick `OK: appstruktur finns`. 
- Inga andra automatiserade tester kördes för denna dokumentationsändring.

Nästa enklaste steg för dig är ...

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994f23c0d4c832883589eb0033b3cba)