### PR TITLE
Lägg till kodlås för familjeläge med säkerhetslogg och autolås

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,15 @@ Det här dokumentet är skrivet för dig som vill **bygga, testa och publicera a
 - Ny to-do/funktionskarta är skapad i `to-do/readme.md` med uppdelning: klart, delvis klart, planerat och arkitekturstatus.
 - Portal, barnläge och familjeläge har fått ett nytt visuellt premiumlyft med responsiv layout, förbättrad typografi och tydligare CTA-kort.
 - GSAP (animationsbibliotek) är installerat och används lokalt via `assets/vendor/gsap.min.js` för mjuka mikroanimationer i barnläget.
+- Familjeläget har nu kodlås för föräldrafunktioner med initial testkod `1234`, lokal säkerhetslogg och automatisk låsning efter inaktivitet (5 minuter).
 
 ### Föreslagna nästa aktiviteter
-1. Bekräfta om serverdel ska ligga i samma repo eller separat repo.
-2. Om separat server: dokumentera exakt WS/API-kontrakt i README.
-3. Koppla familjeappens knappar till riktig data/API när backend finns.
+1. Byt från testkod till riktig personlig kod per familj och lagra den säkrare (hash/krypterad variant).
+2. Koppla familjeappens snabbåtgärder till riktig backend/API i stället för simulerad logg.
+3. Lägg till valbar extra säkerhet i mobil (biometri via native wrapper).
 
 ### Pågående aktivitet (nu)
-- Förbereda nästa steg för backend-koppling så nya premiumgränssnittet kan läsa riktig incidentdata.
+- Förbereda backend-koppling för säkrare inloggning i familjeläge och central loggdelning mellan enheter.
 
 ### Kvar att göra
 - Lägga tillbaka/ansluta serverkod för full WebSocket- och incidentkedja i detta repo.
@@ -49,6 +50,7 @@ Det här dokumentet är skrivet för dig som vill **bygga, testa och publicera a
 - Definiera vilka loggfält som ska exporteras/delas utanför browsern.
 - Fortsätt använda parentesförklaringar för tekniska ord i all användarnära dokumentation.
 - Slutföra produktionsdeploy med `./scripts/netlify-deploy.sh prod` (eller `netlify deploy --prod --dir=panik-overlay`) efter att CLI-login är klart.
+- Flytta föräldrakod till servervalidering för att undvika att kod ligger synligt i klientkod.
 
 ---
 

--- a/panik-overlay/apps/family/index.html
+++ b/panik-overlay/apps/family/index.html
@@ -11,12 +11,13 @@
   <div class="ambient ambient-a" aria-hidden="true"></div>
   <div class="ambient ambient-b" aria-hidden="true"></div>
 
-  <main class="family-shell">
+  <main class="family-shell" id="familyShell" aria-hidden="true" inert>
     <header class="hero">
       <a class="back-link" href="/index.html">← Till appval</a>
       <p class="eyebrow">Familjeläge</p>
       <h1>Trygghetsöversikt i realtid</h1>
       <p class="lead">Samma grundprincip: tydlig status, snabb åtgärd och logg. Nu med mer professionell dashboard-känsla.</p>
+      <button id="lockAgainBtn" class="ghost-btn" type="button">Lås familjeläge igen</button>
     </header>
 
     <section class="kpi-grid" aria-label="Snabbstatus">
@@ -37,22 +38,54 @@
     <section class="grid">
       <article class="panel">
         <h2>Snabbåtgärder</h2>
-        <button>Ring upp barnet</button>
-        <button>Skicka trygghetsmeddelande</button>
-        <button>Öppna delad plats</button>
+        <button data-action="Ring upp barnet">Ring upp barnet</button>
+        <button data-action="Skicka trygghetsmeddelande">Skicka trygghetsmeddelande</button>
+        <button data-action="Öppna delad plats">Öppna delad plats</button>
       </article>
 
       <article class="panel panel-wide">
         <h2>Händelselogg (senaste 24 timmar)</h2>
-        <ul>
+        <ul id="eventList">
           <li><span>13:54</span> Testsignal mottagen</li>
           <li><span>13:21</span> Position uppdaterad</li>
           <li><span>11:07</span> Check-in klar</li>
           <li><span>09:42</span> Appen öppnades i barnläge</li>
         </ul>
       </article>
+
+      <article class="panel panel-wide security-log">
+        <h2>Säkerhetslogg (lokalt i denna enhet)</h2>
+        <p class="tiny">Visar senaste händelser för kodlås och åtgärder. Lagring sker i browsern via localStorage.</p>
+        <ul id="securityLogList">
+          <li>Ingen säkerhetslogg ännu.</li>
+        </ul>
+      </article>
     </section>
   </main>
+
+  <section id="parentLock" class="parent-lock" aria-live="polite">
+    <div class="lock-card" role="dialog" aria-modal="true" aria-labelledby="lockTitle">
+      <p class="eyebrow">Skyddat läge</p>
+      <h2 id="lockTitle">Föräldrakod krävs</h2>
+      <p class="lock-copy">Ange föräldrakoden för att öppna familjefunktionerna. Initial testkod är <strong>1234</strong>.</p>
+      <form id="codeForm" class="code-form">
+        <label for="parentCodeInput">Kod</label>
+        <input id="parentCodeInput" inputmode="numeric" pattern="[0-9]*" minlength="4" maxlength="8" autocomplete="off" placeholder="••••" required />
+        <button type="submit">Lås upp</button>
+      </form>
+      <p id="lockMessage" class="lock-message">Tips: byt kod i inställningar innan skarp drift.</p>
+      <details>
+        <summary>Smart nästa nivå (förslag)</summary>
+        <ul class="ideas">
+          <li>Byt från fast testkod till personlig PIN + hash (krypterat fingeravtryck av koden).</li>
+          <li>Lägg till timeout (automatisk låsning) efter inaktivitet.</li>
+          <li>Komplettera med biometrisk upplåsning i mobilskal (Face ID/Touch ID via native wrapper).</li>
+        </ul>
+      </details>
+    </div>
+  </section>
+
+  <script src="/apps/family/script.js" defer></script>
   <script src="/assets/js/pwa.js"></script>
 </body>
 </html>

--- a/panik-overlay/apps/family/script.js
+++ b/panik-overlay/apps/family/script.js
@@ -1,0 +1,161 @@
+const TEST_PARENT_CODE = "1234";
+const SECURITY_LOG_KEY = "familySecurityLog";
+const SESSION_UNLOCK_KEY = "familyUnlockedAt";
+const AUTO_LOCK_MS = 5 * 60 * 1000;
+
+const familyShell = document.getElementById("familyShell");
+const parentLock = document.getElementById("parentLock");
+const codeForm = document.getElementById("codeForm");
+const parentCodeInput = document.getElementById("parentCodeInput");
+const lockMessage = document.getElementById("lockMessage");
+const securityLogList = document.getElementById("securityLogList");
+const eventList = document.getElementById("eventList");
+const lockAgainBtn = document.getElementById("lockAgainBtn");
+
+let autoLockTimer = null;
+
+function nowLabel() {
+  return new Date().toLocaleString("sv-SE", {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    day: "2-digit",
+    month: "short"
+  });
+}
+
+function readSecurityLog() {
+  return JSON.parse(localStorage.getItem(SECURITY_LOG_KEY) || "[]");
+}
+
+function saveSecurityLog(logItems) {
+  localStorage.setItem(SECURITY_LOG_KEY, JSON.stringify(logItems.slice(0, 25)));
+}
+
+function appendSecurityLog(text) {
+  const logs = readSecurityLog();
+  logs.unshift({ at: new Date().toISOString(), text });
+  saveSecurityLog(logs);
+  renderSecurityLog();
+}
+
+function renderSecurityLog() {
+  const logs = readSecurityLog();
+
+  if (!logs.length) {
+    securityLogList.innerHTML = "<li>Ingen säkerhetslogg ännu.</li>";
+    return;
+  }
+
+  securityLogList.innerHTML = logs
+    .map((item) => `<li><span>${new Date(item.at).toLocaleTimeString("sv-SE")}</span> ${item.text}</li>`)
+    .join("");
+}
+
+function setLockedState(isLocked) {
+  familyShell.dataset.locked = String(isLocked);
+  familyShell.ariaHidden = String(isLocked);
+
+  if (isLocked) {
+    familyShell.setAttribute("inert", "");
+    parentLock.hidden = false;
+    parentCodeInput.value = "";
+    parentCodeInput.focus();
+    lockMessage.textContent = "Ange koden för att öppna familjeläge.";
+    lockMessage.classList.remove("error");
+    return;
+  }
+
+  familyShell.removeAttribute("inert");
+  parentLock.hidden = true;
+}
+
+function markUnlocked() {
+  localStorage.setItem(SESSION_UNLOCK_KEY, String(Date.now()));
+  appendSecurityLog("Familjeläge upplåst med kod.");
+  setLockedState(false);
+  resetAutoLock();
+}
+
+function shouldStayUnlocked() {
+  const unlockedAt = Number(localStorage.getItem(SESSION_UNLOCK_KEY) || "0");
+  if (!unlockedAt) return false;
+  return Date.now() - unlockedAt < AUTO_LOCK_MS;
+}
+
+function lockFamily(reason) {
+  localStorage.removeItem(SESSION_UNLOCK_KEY);
+  appendSecurityLog(reason || "Familjeläge låstes.");
+  setLockedState(true);
+
+  if (autoLockTimer) {
+    window.clearTimeout(autoLockTimer);
+    autoLockTimer = null;
+  }
+}
+
+function resetAutoLock() {
+  if (autoLockTimer) {
+    window.clearTimeout(autoLockTimer);
+  }
+
+  autoLockTimer = window.setTimeout(() => {
+    lockFamily("Automatisk låsning efter inaktivitet.");
+  }, AUTO_LOCK_MS);
+}
+
+function addFamilyActionLog(actionText) {
+  const item = document.createElement("li");
+  item.innerHTML = `<span>${nowLabel()}</span> ${actionText}`;
+  eventList.prepend(item);
+
+  while (eventList.children.length > 10) {
+    eventList.removeChild(eventList.lastElementChild);
+  }
+}
+
+codeForm.addEventListener("submit", (event) => {
+  event.preventDefault();
+  const enteredCode = parentCodeInput.value.trim();
+
+  if (enteredCode === TEST_PARENT_CODE) {
+    lockMessage.textContent = "Kod godkänd. Familjeläge öppnas.";
+    lockMessage.classList.remove("error");
+    markUnlocked();
+    return;
+  }
+
+  lockMessage.textContent = "Fel kod. Försök igen.";
+  lockMessage.classList.add("error");
+  appendSecurityLog("Misslyckat kodförsök i familjeläge.");
+  parentCodeInput.select();
+});
+
+lockAgainBtn.addEventListener("click", () => {
+  lockFamily("Manuell låsning via knappen 'Lås familjeläge igen'.");
+});
+
+document.querySelectorAll("button[data-action]").forEach((button) => {
+  button.addEventListener("click", () => {
+    const action = button.dataset.action;
+    appendSecurityLog(`Snabbåtgärd använd: ${action}.`);
+    addFamilyActionLog(`${action} (simulerad åtgärd)`);
+    resetAutoLock();
+  });
+});
+
+["click", "keydown", "touchstart"].forEach((eventName) => {
+  familyShell.addEventListener(eventName, () => {
+    if (parentLock.hidden) resetAutoLock();
+  });
+});
+
+if (shouldStayUnlocked()) {
+  setLockedState(false);
+  appendSecurityLog("Familjeläge återöppnades via aktiv session.");
+  resetAutoLock();
+} else {
+  setLockedState(true);
+}
+
+renderSecurityLog();

--- a/panik-overlay/apps/family/style.css
+++ b/panik-overlay/apps/family/style.css
@@ -6,6 +6,7 @@
   --muted: #bbcae9;
   --accent: #59dfff;
   --ok: #2fd49f;
+  --warn: #ff9090;
 }
 
 * { box-sizing: border-box; }
@@ -38,6 +39,12 @@ body {
   gap: 0.9rem;
   position: relative;
   z-index: 1;
+}
+
+.family-shell[data-locked="true"] {
+  filter: blur(5px);
+  pointer-events: none;
+  user-select: none;
 }
 
 .hero,
@@ -135,4 +142,80 @@ li span {
   color: #9cd7ff;
   font-weight: 700;
   margin-right: 0.35rem;
+}
+
+.parent-lock {
+  position: fixed;
+  inset: 0;
+  z-index: 20;
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+  background: rgba(2, 8, 20, 0.72);
+  backdrop-filter: blur(8px);
+}
+
+.lock-card {
+  width: min(460px, 100%);
+  background: rgba(9, 21, 44, 0.95);
+  border: 1px solid rgba(137, 188, 255, 0.38);
+  border-radius: 20px;
+  padding: 1rem;
+  box-shadow: 0 14px 42px rgba(0, 0, 0, 0.38);
+}
+
+.lock-copy {
+  color: var(--muted);
+}
+
+.code-form {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.code-form label {
+  font-weight: 700;
+  font-size: 0.92rem;
+}
+
+.code-form input {
+  width: 100%;
+  padding: 0.76rem;
+  border-radius: 12px;
+  border: 1px solid rgba(144, 198, 255, 0.45);
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text);
+  font-size: 1rem;
+  letter-spacing: 0.08em;
+}
+
+.lock-message {
+  min-height: 1.4rem;
+  color: var(--accent);
+  font-size: 0.92rem;
+  margin-bottom: 0.3rem;
+}
+
+.lock-message.error {
+  color: var(--warn);
+}
+
+.ideas {
+  margin-top: 0.5rem;
+}
+
+.ideas li {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.tiny {
+  color: var(--muted);
+  font-size: 0.86rem;
+}
+
+.ghost-btn {
+  width: fit-content;
+  margin-top: 0.2rem;
+  background: transparent;
+  border-color: rgba(167, 220, 255, 0.52);
 }

--- a/panik-overlay/package.json
+++ b/panik-overlay/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Webbapp med barnläge och familjeläge för Panikknappen",
   "scripts": {
-    "check": "node -e \"const fs=require('fs');['index.html','assets/css/portal.css','assets/vendor/gsap.min.js','apps/child/index.html','apps/child/style.css','apps/child/script.js','apps/family/index.html','apps/family/style.css'].forEach(f=>{if(!fs.existsSync(f)){throw new Error('Saknar fil: '+f)}}); console.log('OK: appstruktur finns');\"",
+    "check": "node -e \"const fs=require('fs');['index.html','assets/css/portal.css','assets/vendor/gsap.min.js','apps/child/index.html','apps/child/style.css','apps/child/script.js','apps/family/index.html','apps/family/style.css','apps/family/script.js'].forEach(f=>{if(!fs.existsSync(f)){throw new Error('Saknar fil: '+f)}}); console.log('OK: appstruktur finns');\"",
     "preview": "npx --yes serve . -l 4173"
   },
   "dependencies": {


### PR DESCRIPTION
### Motivation
- Familjeläget ska vara skyddat så att endast vuxna/föräldrar kan nå känsliga funktioner, därför införs ett enkelt kodlås för att skydda familjefunktionerna (initial testkod `1234`).
- Lösningen ska fungera både i webbläsaren och i PWA/mobilinstallationen och ge spårbarhet via lokal loggning innan en serverbaserad lösning finns.

### Description
- Lagt till lås-UI/overlay i `panik-overlay/apps/family/index.html` med ett inputfält för föräldrakod och en knapp för att manuellt låsa om (`Lås familjeläge igen`).
- Ny klientlogik i `panik-overlay/apps/family/script.js` som hanterar testkoden `TEST_PARENT_CODE = "1234"`, session/unlock i `localStorage`, säkerhetslogg (`familySecurityLog`), autolås efter 5 minuter och loggning av misslyckade lyckade försök samt snabbåtgärder.
- Uppdaterad styling i `panik-overlay/apps/family/style.css` för låst state (blur/disabled) och lås-dialogens utseende, samt lagt till en lokal säkerhetsloggvy i familje-UI:t.
- Uppdaterat `panik-overlay/package.json` check-script så att nya filen `apps/family/script.js` inkluderas och uppdaterat `README.md` med status och rekommenderade nästa steg (byt testkod mot servervalidering/hashing och biometri-förslag).

### Testing
- Körning av strukturell check med `cd panik-overlay && npm run check` kördes och rapporterade `OK: appstruktur finns` (lyckades).
- Start av lokal preview med `cd panik-overlay && npm run preview` användes för visuell verifiering och laddade familjesidan framgångsrikt (manuell/automatisk kontroll).
- Automatisk verifiering med Playwright körde ett skript som öppnade `http://127.0.0.1:4173/apps/family/index.html`, fyllde i koden `1234`, tryckte på "Lås upp" och skapade en skärmdump (`artifacts/family-parent-lock.png`), vilket bekräftade att upplåsningen och loggningen fungerar (lyckades).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995053c677c8328b44d2355f1e0bc0b)