### PR TITLE
Felsökning: stabilare `check` och token-stöd i Netlify-deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,12 @@ Det här dokumentet är skrivet för dig som vill **bygga, testa och publicera a
 - Förslag på familjeapp-design finns i `panik-overlay/apps/family/`.
 - Netlify-konfiguration (`netlify.toml`) är verifierad med `publish = "panik-overlay"`, Node 20 och redirect för SPA (single page app/en-sides-app).
 - Deploy-test via `npx netlify-cli deploy --dir=panik-overlay` är kört i CI/container och stoppade vid Netlify-login (inloggning) eftersom browser-öppning saknas i miljön.
-- Nytt hjälpscript `scripts/netlify-deploy.sh` finns för preview/prod-deploy (publicering) med samma mappval (`panik-overlay`).
+- Nytt hjälpscript `scripts/netlify-deploy.sh` finns för preview/prod-deploy (publicering) med samma mappval (`panik-overlay`) och stöd för `NETLIFY_AUTH_TOKEN` (token för inloggad CLI-körning utan browser).
 - Ny to-do/funktionskarta är skapad i `to-do/readme.md` med uppdelning: klart, delvis klart, planerat och arkitekturstatus.
 - Portal, barnläge och familjeläge har fått ett nytt visuellt premiumlyft med responsiv layout, förbättrad typografi och tydligare CTA-kort.
 - GSAP (animationsbibliotek) är installerat och används lokalt via `assets/vendor/gsap.min.js` för mjuka mikroanimationer i barnläget.
 - Familjeläget har nu kodlås för föräldrafunktioner med initial testkod `1234`, lokal säkerhetslogg och automatisk låsning efter inaktivitet (5 minuter).
+- Felsökning klar: `panik-overlay/package.json` hade dubbla `check`-nycklar (konfigurationsfält), nu ersatt med en enda check som verifierar både familjeläge-script och lås-script.
 
 ### Föreslagna nästa aktiviteter
 1. Byt från testkod till riktig personlig kod per familj och lagra den säkrare (hash/krypterad variant).
@@ -41,7 +42,7 @@ Det här dokumentet är skrivet för dig som vill **bygga, testa och publicera a
 3. Lägg till valbar extra säkerhet i mobil (biometri via native wrapper).
 
 ### Pågående aktivitet (nu)
-- Förbereda backend-koppling för säkrare inloggning i familjeläge och central loggdelning mellan enheter.
+- Felsökning + deployflöde för Netlify CLI så deploy fungerar både med browser-login och token i container/CI.
 
 ### Kvar att göra
 - Lägga tillbaka/ansluta serverkod för full WebSocket- och incidentkedja i detta repo.
@@ -50,7 +51,7 @@ Det här dokumentet är skrivet för dig som vill **bygga, testa och publicera a
 - Flytta föräldrakod från lokal lagring till säkrare serverkontroll när backend är redo.
 - Definiera vilka loggfält som ska exporteras/delas utanför browsern.
 - Fortsätt använda parentesförklaringar för tekniska ord i all användarnära dokumentation.
-- Slutföra produktionsdeploy med `./scripts/netlify-deploy.sh prod` (eller `netlify deploy --prod --dir=panik-overlay`) efter att CLI-login är klart.
+- Slutföra produktionsdeploy med `./scripts/netlify-deploy.sh prod` (eller `netlify deploy --prod --dir=panik-overlay`) efter att CLI-login är klart eller `NETLIFY_AUTH_TOKEN` är satt i miljön.
 - Flytta föräldrakod till servervalidering för att undvika att kod ligger synligt i klientkod.
 
 ---

--- a/panik-overlay/package.json
+++ b/panik-overlay/package.json
@@ -4,8 +4,7 @@
   "private": true,
   "description": "Webbapp med barnläge och familjeläge för Panikknappen",
   "scripts": {
-    "check": "node -e \"const fs=require('fs');['index.html','assets/css/portal.css','assets/vendor/gsap.min.js','apps/child/index.html','apps/child/style.css','apps/child/script.js','apps/family/index.html','apps/family/style.css','assets/js/family-lock.js'].forEach(f=>{if(!fs.existsSync(f)){throw new Error('Saknar fil: '+f)}}); console.log('OK: appstruktur finns');\"",
-    "check": "node -e \"const fs=require('fs');['index.html','assets/css/portal.css','assets/vendor/gsap.min.js','apps/child/index.html','apps/child/style.css','apps/child/script.js','apps/family/index.html','apps/family/style.css','apps/family/script.js'].forEach(f=>{if(!fs.existsSync(f)){throw new Error('Saknar fil: '+f)}}); console.log('OK: appstruktur finns');\"",
+    "check": "node -e \"const fs=require('fs');['index.html','assets/css/portal.css','assets/vendor/gsap.min.js','apps/child/index.html','apps/child/style.css','apps/child/script.js','apps/family/index.html','apps/family/style.css','apps/family/script.js','assets/js/family-lock.js'].forEach(f=>{if(!fs.existsSync(f)){throw new Error('Saknar fil: '+f)}}); console.log('OK: appstruktur finns');\"",
     "preview": "npx --yes serve . -l 4173"
   },
   "dependencies": {

--- a/scripts/netlify-deploy.sh
+++ b/scripts/netlify-deploy.sh
@@ -21,8 +21,14 @@ echo "Kör Netlify deploy från: $ROOT_DIR"
 
 echo "Tips: Om login krävs, öppna URL:en från terminalen i din vanliga browser och godkänn."
 
+AUTH_ARGS=()
+if [[ -n "${NETLIFY_AUTH_TOKEN:-}" ]]; then
+  echo "NETLIFY_AUTH_TOKEN hittades och används för icke-interaktiv deploy."
+  AUTH_ARGS+=(--auth "$NETLIFY_AUTH_TOKEN")
+fi
+
 if [[ "$MODE" == "prod" ]]; then
-  npx --yes netlify-cli deploy --prod --dir=panik-overlay
+  npx --yes netlify-cli deploy --prod --dir=panik-overlay "${AUTH_ARGS[@]}"
 else
-  npx --yes netlify-cli deploy --dir=panik-overlay
+  npx --yes netlify-cli deploy --dir=panik-overlay "${AUTH_ARGS[@]}"
 fi


### PR DESCRIPTION
### Motivation
- Fixa att CI/container körningar blockerades av två problem: ett trasigt `check`-script i `panik-overlay/package.json` och att Netlify CLI kräver browser-login i containermiljö. (deploy = publicera till webben)

### Description
- Rensade dubbel `check`-nyckel i `panik-overlay/package.json` och slog ihop till en enda `check` som verifierar både familje-script och lås-script genom att kontrollera `apps/family/script.js` och `assets/js/family-lock.js` med `node`-kontroll. 
- Uppdaterade `scripts/netlify-deploy.sh` så att den kan använda `NETLIFY_AUTH_TOKEN` (token för Netlify CLI) för icke-interaktiv deploy (utan browser-popup), och skickar token vidare som `--auth` till `netlify-cli`. 
- Uppdaterade `README.md` statuslogg för att förklara felsökningen och att produktion/preview-deploy nu kan köras med `NETLIFY_AUTH_TOKEN` i miljön. (repo = projektmapp)

### Testing
- Körde `cd panik-overlay && npm run check` och fick `OK: appstruktur finns`, vilket verifierar att kontrollscriptet fungerar ✅. 
- Försökte `./scripts/netlify-deploy.sh preview` i containern, vilket blockerades av Netlify-login eftersom containern inte kan öppna browser automatiskt, men scriptet använder nu `NETLIFY_AUTH_TOKEN` för att undvika detta i CI/icke-interaktiv miljö ⚠️. 
- Alla ändrade filer (`panik-overlay/package.json`, `scripts/netlify-deploy.sh`, `README.md`) är uppdaterade för att reflektera dessa förändringar.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69950ed4e3488328a2619ccacfdbbd02)