### PR TITLE
Fixa Netlify deploy-script och tydliggör token/site-id-flöde

### DIFF
--- a/NETLIFY_DEPLOY.md
+++ b/NETLIFY_DEPLOY.md
@@ -32,6 +32,8 @@ Om Netlify CLI (terminalverktyg) ber om login (inloggning) och inte kan öppna b
 ```bash
 cd /workspace/PanikknappenV2
 export NETLIFY_AUTH_TOKEN='<din-token>'
+# valfritt men rekommenderat i CI/container:
+export NETLIFY_SITE_ID='<din-site-id>'
 ./scripts/netlify-deploy.sh preview
 ```
 
@@ -40,6 +42,8 @@ För produktion:
 ```bash
 cd /workspace/PanikknappenV2
 export NETLIFY_AUTH_TOKEN='<din-token>'
+# valfritt men rekommenderat i CI/container:
+export NETLIFY_SITE_ID='<din-site-id>'
 ./scripts/netlify-deploy.sh prod
 ```
 
@@ -53,5 +57,6 @@ export NETLIFY_AUTH_TOKEN='<din-token>'
 - Preview: `npx --yes netlify-cli deploy --dir=panik-overlay`
 - Produktion: `npx --yes netlify-cli deploy --prod --dir=panik-overlay`
 - Om `NETLIFY_AUTH_TOKEN` finns lägger scriptet till `--auth <token>` automatiskt för non-interactive deploy (utan browser-login).
+- Om `NETLIFY_SITE_ID` finns lägger scriptet till `--site <site-id>` för tydlig koppling mot rätt Netlify-site i CI/container.
 
 Det betyder att site-mappen (mappen som publiceras) alltid är `panik-overlay`.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Det här dokumentet är skrivet för dig som vill **bygga, testa och publicera a
 - GSAP (animationsbibliotek) är installerat och används lokalt via `assets/vendor/gsap.min.js` för mjuka mikroanimationer i barnläget.
 - Familjeläget har nu kodlås för föräldrafunktioner med initial testkod `1234`, lokal säkerhetslogg och automatisk låsning efter inaktivitet (5 minuter).
 - Felsökning klar: `panik-overlay/package.json` hade dubbla `check`-nycklar (konfigurationsfält), nu ersatt med en enda check som verifierar både familjeläge-script och lås-script.
+- Felsökning klar: `scripts/netlify-deploy.sh` använder nu samma argumentkedja utan dubbletter och stödjer även `NETLIFY_SITE_ID` (site-id för direkt koppling i CI/container).
 
 ### Föreslagna nästa aktiviteter
 1. Byt från testkod till riktig personlig kod per familj och lagra den säkrare (hash/krypterad variant).
@@ -42,7 +43,7 @@ Det här dokumentet är skrivet för dig som vill **bygga, testa och publicera a
 3. Lägg till valbar extra säkerhet i mobil (biometri via native wrapper).
 
 ### Pågående aktivitet (nu)
-- Felsökning + deployflöde för Netlify CLI så deploy fungerar både med browser-login och token i container/CI.
+- Produktionsdeploy med riktig token/site-id i Netlify-konto för att verifiera live-länk efter scriptfix.
 
 ### Kvar att göra
 - Lägga tillbaka/ansluta serverkod för full WebSocket- och incidentkedja i detta repo.
@@ -51,7 +52,7 @@ Det här dokumentet är skrivet för dig som vill **bygga, testa och publicera a
 - Flytta föräldrakod från lokal lagring till säkrare serverkontroll när backend är redo.
 - Definiera vilka loggfält som ska exporteras/delas utanför browsern.
 - Fortsätt använda parentesförklaringar för tekniska ord i all användarnära dokumentation.
-- Slutföra produktionsdeploy med `./scripts/netlify-deploy.sh prod` (eller `netlify deploy --prod --dir=panik-overlay`) efter att CLI-login är klart eller `NETLIFY_AUTH_TOKEN` är satt i miljön.
+- Slutföra produktionsdeploy med `./scripts/netlify-deploy.sh prod` (eller `netlify deploy --prod --dir=panik-overlay`) efter att CLI-login är klart eller `NETLIFY_AUTH_TOKEN` + `NETLIFY_SITE_ID` är satta i miljön.
 - Flytta föräldrakod till servervalidering för att undvika att kod ligger synligt i klientkod.
 
 ---

--- a/scripts/netlify-deploy.sh
+++ b/scripts/netlify-deploy.sh
@@ -5,6 +5,7 @@ MODE="${1:-preview}"
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SITE_DIR="$ROOT_DIR/panik-overlay"
 AUTH_TOKEN="${NETLIFY_AUTH_TOKEN:-}"
+SITE_ID="${NETLIFY_SITE_ID:-}"
 
 if [[ ! -d "$SITE_DIR" ]]; then
   echo "Fel: hittar inte mappen panik-overlay i repo-roten."
@@ -20,31 +21,31 @@ cd "$ROOT_DIR"
 
 echo "Kör Netlify deploy från: $ROOT_DIR"
 
+AUTH_ARGS=()
 if [[ -n "$AUTH_TOKEN" ]]; then
-  echo "NETLIFY_AUTH_TOKEN hittad: kör non-interactive deploy (utan browser-login)."
-  AUTH_ARGS=(--auth "$AUTH_TOKEN")
+  echo "NETLIFY_AUTH_TOKEN hittades och används för icke-interaktiv deploy."
+  AUTH_ARGS+=(--auth "$AUTH_TOKEN")
+elif [[ ! -t 1 ]]; then
+  echo "Fel: ingen terminal-session för browser-login och NETLIFY_AUTH_TOKEN saknas."
+  echo "Lösning:"
+  echo "  1) Skapa en Personal Access Token i Netlify (User settings > Applications > Personal access tokens)."
+  echo "  2) Kör i repo-roten:"
+  echo "     export NETLIFY_AUTH_TOKEN='<din-token>'"
+  echo "  3) Kör deploy igen: ./scripts/netlify-deploy.sh $MODE"
+  exit 1
 else
-  AUTH_ARGS=()
-  if [[ ! -t 1 ]]; then
-    echo "Fel: ingen terminal-session för browser-login och NETLIFY_AUTH_TOKEN saknas."
-    echo "Lösning:"
-    echo "  1) Skapa en Personal Access Token i Netlify (User settings > Applications > Personal access tokens)."
-    echo "  2) Kör i repo-roten:"
-    echo "     export NETLIFY_AUTH_TOKEN='<din-token>'"
-    echo "  3) Kör deploy igen: ./scripts/netlify-deploy.sh $MODE"
-    exit 1
-  fi
   echo "Tips: Om login krävs, öppna URL:en från terminalen i din vanliga browser och godkänn."
 fi
 
-AUTH_ARGS=()
-if [[ -n "${NETLIFY_AUTH_TOKEN:-}" ]]; then
-  echo "NETLIFY_AUTH_TOKEN hittades och används för icke-interaktiv deploy."
-  AUTH_ARGS+=(--auth "$NETLIFY_AUTH_TOKEN")
+SITE_ARGS=()
+if [[ -n "$SITE_ID" ]]; then
+  echo "NETLIFY_SITE_ID hittades och skickas med till Netlify CLI."
+  SITE_ARGS+=(--site "$SITE_ID")
 fi
 
+DEPLOY_ARGS=(deploy --dir=panik-overlay "${AUTH_ARGS[@]}" "${SITE_ARGS[@]}")
 if [[ "$MODE" == "prod" ]]; then
-  npx --yes netlify-cli deploy --prod --dir=panik-overlay "${AUTH_ARGS[@]}"
-else
-  npx --yes netlify-cli deploy --dir=panik-overlay "${AUTH_ARGS[@]}"
+  DEPLOY_ARGS+=(--prod)
 fi
+
+npx --yes netlify-cli "${DEPLOY_ARGS[@]}"


### PR DESCRIPTION
### Motivation
- Stabilisera deploy-flödet för Netlify i container/CI (non-interactive terminal) genom att ta bort dubbletter och göra argumenthanteringen tydlig. 
- Göra det enkelt för nybörjare att köra preview/production deploy med copy/paste-instruktioner för `NETLIFY_AUTH_TOKEN` (access-token) och `NETLIFY_SITE_ID` (site-id). 

### Description
- Rensat och omstrukturerat `scripts/netlify-deploy.sh` så att `AUTH_ARGS`, `SITE_ARGS` och `DEPLOY_ARGS` byggs en gång och skickas korrekt till `netlify-cli` (terminalverktyg). 
- Lagt till stöd för `NETLIFY_SITE_ID` så CI/container kan peka mot rätt Netlify-site med `--site <site-id>`. 
- Behållit tydlig fallback vid env utan TTY så scriptet ger instruktioner om att exportera en token istället för att försöka browser-login. 
- Uppdaterat `NETLIFY_DEPLOY.md` och `README.md` med copy/paste-kommandon för `NETLIFY_AUTH_TOKEN` och valfritt `NETLIFY_SITE_ID` samt statuslogg. 

### Testing
- Körning av `cd panik-overlay && npm run check` verifierade att nödvändig appstruktur finns och rapporterade `OK: appstruktur finns`. 
- Shell-syntaxkontroll `bash -n scripts/netlify-deploy.sh` lyckades utan fel. 
- Körning av `./scripts/netlify-deploy.sh preview` i non-TTY utan token gav det förväntade tydliga felmeddelandet om att `NETLIFY_AUTH_TOKEN` saknas. 
- Körning av `NETLIFY_AUTH_TOKEN=dummy NETLIFY_SITE_ID=dummy ./scripts/netlify-deploy.sh preview` demonstrerade att flaggor skickas men slutade med `Unauthorized` med dummy-token, vilket visar att argumenten når Netlify CLI; commit gjordes och PR-text skapades. 
- Nästa enklaste steg för dig är att exportera en giltig `NETLIFY_AUTH_TOKEN` och `NETLIFY_SITE_ID` i terminalen och köra `./scripts/netlify-deploy.sh prod` i repo-roten (`/workspace/PanikknappenV2`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699514c17680832893ab2b3d5a443bff)