### PR TITLE
Fix: relativa sökvägar för barn- och familjesidor (löser 404 vid deploy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Det här dokumentet är skrivet för dig som vill **bygga, testa och publicera a
 - Strategibyte klart: deploy-spåret går nu via GitHub Pages (GitHub-hosting) med nytt workflow för statisk publicering från `panik-overlay`.
 - Förtydligat: Netlify-workflow körs nu endast manuellt (workflow_dispatch) så GitHub Pages förblir huvudspår utan automatisk Netlify-körning på `main`.
 - Uppföljning klar: PR-spåret är flyttat till branch `Variant_3` för vidare ändringar i ett eget, tydligt arbetsflöde.
+- Felsökning klar: barn- och familjesidan använder nu relativa filvägar (sökvägar utan inledande `/`) så CSS/JS/back-länkar fungerar även efter deploy på undersökväg (t.ex. GitHub Pages).
 
 ### Föreslagna nästa aktiviteter
 1. Byt från testkod till riktig personlig kod per familj och lagra den säkrare (hash/krypterad variant).
@@ -67,7 +68,7 @@ Det här dokumentet är skrivet för dig som vill **bygga, testa och publicera a
 3. Lägg till valbar extra säkerhet i mobil (biometri via native wrapper).
 
 ### Pågående aktivitet (nu)
-- Verifiera GitHub Pages-deploy (publicering) via Actions och uppdatera live-länk i README (Netlify är pausad fallback under provperioden).
+- Verifiera nästa online-deploy efter länkfixen för barn/familj och bekräfta att båda undersidorna laddar korrekt.
 
 ### Kvar att göra
 - Lägga tillbaka/ansluta serverkod för full WebSocket- och incidentkedja i detta repo.

--- a/panik-overlay/apps/child/index.html
+++ b/panik-overlay/apps/child/index.html
@@ -5,10 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <title>Panikknapp – Barnläge</title>
   <meta name="theme-color" content="#040a1b" />
-  <link rel="manifest" href="/manifest.webmanifest" />
-  <link rel="apple-touch-icon" href="/assets/icons/icon.svg" />
-  <link rel="stylesheet" href="/apps/child/style.css" />
-  <link rel="stylesheet" href="/assets/css/pwa.css" />
+  <link rel="manifest" href="../../manifest.webmanifest" />
+  <link rel="apple-touch-icon" href="../../assets/icons/icon.svg" />
+  <link rel="stylesheet" href="./style.css" />
+  <link rel="stylesheet" href="../../assets/css/pwa.css" />
 </head>
 <body>
   <div class="ambient ambient-a" aria-hidden="true"></div>
@@ -16,7 +16,7 @@
 
   <main class="app-shell">
     <header class="topbar" aria-label="Inställningar">
-      <a class="back-link" href="/index.html">← Till appval</a>
+      <a class="back-link" href="../../index.html">← Till appval</a>
       <label for="languageSelect" id="languageLabel">Språk</label>
       <select id="languageSelect" aria-labelledby="languageLabel">
         <option value="sv">Svenska</option>
@@ -53,8 +53,8 @@
     </section>
   </main>
 
-  <script src="/assets/vendor/gsap.min.js"></script>
-  <script src="/apps/child/script.js"></script>
-  <script src="/assets/js/pwa.js"></script>
+  <script src="../../assets/vendor/gsap.min.js"></script>
+  <script src="./script.js"></script>
+  <script src="../../assets/js/pwa.js"></script>
 </body>
 </html>

--- a/panik-overlay/apps/family/index.html
+++ b/panik-overlay/apps/family/index.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Familjeläge – Panikknappen</title>
-  <link rel="stylesheet" href="/apps/family/style.css" />
-  <link rel="stylesheet" href="/assets/css/pwa.css" />
+  <link rel="stylesheet" href="./style.css" />
+  <link rel="stylesheet" href="../../assets/css/pwa.css" />
 </head>
 <body>
   <div class="ambient ambient-a" aria-hidden="true"></div>
@@ -13,7 +13,7 @@
 
   <main class="family-shell" id="familyShell" aria-hidden="true" inert>
     <header class="hero">
-      <a class="back-link" href="/index.html">← Till appval</a>
+      <a class="back-link" href="../../index.html">← Till appval</a>
       <p class="eyebrow">Familjeläge</p>
       <h1>Trygghetsöversikt i realtid</h1>
       <p class="lead">Samma grundprincip: tydlig status, snabb åtgärd och logg. Nu med mer professionell dashboard-känsla.</p>
@@ -85,8 +85,8 @@
     </div>
   </section>
 
-  <script src="/apps/family/script.js" defer></script>
-  <script src="/assets/js/pwa.js"></script>
-  <script src="/assets/js/family-lock.js"></script>
+  <script src="./script.js" defer></script>
+  <script src="../../assets/js/pwa.js"></script>
+  <script src="../../assets/js/family-lock.js"></script>
 </body>
 </html>

--- a/panik-overlay/index.html
+++ b/panik-overlay/index.html
@@ -5,10 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Panikknappen V2</title>
   <meta name="theme-color" content="#040a1b" />
-  <link rel="manifest" href="/manifest.webmanifest" />
-  <link rel="apple-touch-icon" href="/assets/icons/icon.svg" />
+  <link rel="manifest" href="./manifest.webmanifest" />
+  <link rel="apple-touch-icon" href="./assets/icons/icon.svg" />
   <link rel="stylesheet" href="./assets/css/portal.css" />
-  <link rel="stylesheet" href="/assets/css/pwa.css" />
+  <link rel="stylesheet" href="./assets/css/pwa.css" />
 </head>
 <body>
   <div class="ambient ambient-a" aria-hidden="true"></div>
@@ -37,6 +37,6 @@
       </a>
     </section>
   </main>
-  <script src="/assets/js/pwa.js"></script>
+  <script src="./assets/js/pwa.js"></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Barn- och familjesidor laddade inte sina CSS/JS/länkar när appen kördes under en undermapp online eftersom många länkar pekade från rot (`/assets/...`), vilket gav 404 vid deploy. 
- Målet är att göra minsta säkra ändring för att sidorna ska fungera både lokalt och när de publiceras (t.ex. GitHub Pages eller Netlify) utan ändring av byggflödet.

### Description
- Bytte absoluta sökvägar till relativa i `panik-overlay/index.html` så manifest, ikoner och `pwa.js` laddas från samma mapp. 
- Uppdaterade länkar i `panik-overlay/apps/child/index.html` till relativa vägar för manifest, ikoner, CSS och JS samt back-länk till `../../index.html`. 
- Uppdaterade länkar i `panik-overlay/apps/family/index.html` till relativa vägar för CSS, JS och back-länk till `../../index.html`. 
- Uppdaterade `README.md` statuslogg för att dokumentera att barn- och familjesidorna nu använder relativa sökvägar.

### Testing
- Körde `npm run check` i `panik-overlay` för att verifiera att alla förväntade filer finns och scriptet rapporterade `OK: appstruktur finns` (pass). 
- Verifierade att inga av de tre HTML-filerna innehåller mönstret `="/` med en snabb `rg`-kontroll, vilket bekräftar att inga absoluta rotvägar finns kvar (pass). 
- Gjorde commit av ändrade filer (`panik-overlay/index.html`, `panik-overlay/apps/child/index.html`, `panik-overlay/apps/family/index.html`, `README.md`) och skapade PR med denna beskrivning. 
- Nästa enklaste steg för dig är att köra en ny deploy (t.ex. `./scripts/netlify-deploy.sh preview` eller din GitHub Pages workflow) och öppna både Barnläge och Familjeläge från startsidan för att bekräfta att båda undersidorna laddar korrekt.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995cdc944308328a7477d74052f8a88)