### PR TITLE
Respektera `hidden` för föräldralås i familjeläget

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Det här dokumentet är skrivet för dig som vill **bygga, testa och publicera a
 - Förtydligat: Netlify-workflow körs nu endast manuellt (workflow_dispatch) så GitHub Pages förblir huvudspår utan automatisk Netlify-körning på `main`.
 - Uppföljning klar: PR-spåret är flyttat till branch `Variant_3` för vidare ändringar i ett eget, tydligt arbetsflöde.
 - Felsökning klar: barn- och familjesidan använder nu relativa filvägar (sökvägar utan inledande `/`) så CSS/JS/back-länkar fungerar även efter deploy på undersökväg (t.ex. GitHub Pages).
+- Felsökning klar (2026-02-18): föräldralåset i familjeläget respekterar nu `hidden`-attributet i CSS, så korrekt kod (`1234`) döljer låsskärmen och släpper fram dashboarden som tänkt.
 
 ### Föreslagna nästa aktiviteter
 1. Byt från testkod till riktig personlig kod per familj och lagra den säkrare (hash/krypterad variant).
@@ -69,6 +70,7 @@ Det här dokumentet är skrivet för dig som vill **bygga, testa och publicera a
 
 ### Pågående aktivitet (nu)
 - Verifiera nästa online-deploy efter länkfixen för barn/familj och bekräfta att båda undersidorna laddar korrekt.
+- Planera nästa steg för att flytta föräldrakod från klient (kod i browsern) till säkrare servervalidering.
 
 ### Kvar att göra
 - Lägga tillbaka/ansluta serverkod för full WebSocket- och incidentkedja i detta repo.

--- a/panik-overlay/apps/family/style.css
+++ b/panik-overlay/apps/family/style.css
@@ -208,6 +208,10 @@ li span {
   backdrop-filter: blur(8px);
 }
 
+.parent-lock[hidden] {
+  display: none;
+}
+
 .lock-card {
   width: min(460px, 100%);
   background: rgba(9, 21, 44, 0.95);


### PR DESCRIPTION
### Motivation
- Familjeläset (overlay) förblev synligt även efter att rätt föräldrakod (`1234`) sattes eftersom CSS alltid gav `.parent-lock` `display: grid`, så `hidden`-attributet användes inte.

### Description
- Lagt till CSS-regel i `panik-overlay/apps/family/style.css`: `.parent-lock[hidden]{display:none;}` så elementet faktiskt döljs när JavaScript sätter `hidden` (dolt element).
- Uppdaterat `README.md` statuslogg för att notera fixen och föreslå nästa säkerhetssteg (flytta PIN från klienten till servervalidering).
- Endast front-end-ändring (CSS) och dokumentation uppdaterad; berörda filer: `panik-overlay/apps/family/style.css`, `README.md`.

### Testing
- Körbarhetscheck: kört `cd panik-overlay && npm run check` i repo-mappen (`/workspace/PanikknappenV2/panik-overlay`) och den passerade (`OK: appstruktur finns`).
- Automatisk verifiering: startade lokal server i `panik-overlay` med `python3 -m http.server 4173 --bind 0.0.0.0` och körde en Playwright-test (test-automation för webbläsare) som fyllde `#parentCodeInput` med `1234` och skickade formuläret; före fix var `display` `grid`, efter fix blev det `none` och overlay försvann som väntat.
- Testerna lyckades och en screenshot sparades som `artifacts/family-unlock-fixed.png` för bevis; inga regressionsändringar krävs.

Nästa enklaste steg för dig är att köra `cd /workspace/PanikknappenV2/panik-overlay && npm run preview` i repo-roten och öppna `http://localhost:4173/apps/family/index.html` i din webbläsare för att prova koden `1234` och bekräfta att dashboarden visas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995d025ceac8328b5e5a74d88445ffb)