### PR TITLE
Fixa Capacitor config och förtydliga Android-sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Det här dokumentet är skrivet för dig som vill **bygga, testa och publicera a
 - Plan klar (2026-02-23): native-spår (riktig mobilapp) är beskrivet steg-för-steg för overlay över andra appar, bakgrundsspårning och säker larmkedja.
 - Dokumentation fixad (2026-02-23): kommandon är nu relative (relativa sökvägar), så samma copy/paste fungerar i macOS/Linux och Windows PowerShell utan `/workspace/...`.
 - Dokumentation fixad (2026-02-23): alla kvarvarande `/workspace/...`-rader i README + NETLIFY_DEPLOY är borttagna för att undvika Windows-felet `Set-Location: Cannot find path`.
+- Felsökning klar (2026-02-23): Capacitor-kommandon är nu förtydligade till `panik-overlay/`, så `android platform has not been added yet` undviks när sync körs från rätt mapp.
 
 ### Föreslagna nästa aktiviteter
 1. Byt från testkod till riktig personlig kod per familj och lagra den säkrare (hash/krypterad variant).
@@ -104,16 +105,23 @@ Detta spår behövs om målet är en knapp som kan ligga över andra appar/spel 
 ### Steg 1: Android wrapper (mobilskal) runt nuvarande app
 Mål: återanvänd nuvarande UI (gränssnitt) men köra som native-app (riktig mobilapp).
 
-Kör i **repo-roten** (projektmapp på GitHub):
+Kör i **repo-roten** först (projektmapp på GitHub):
+
+```bash
+# Alla plattformar
+cd panik-overlay
+```
+
+Kör sedan i **panik-overlay/**:
 
 ```bash
 # Alla plattformar (macOS/Linux/Windows PowerShell)
-# Tips: öppna terminalen direkt i PanikknappenV2-mappen först
-npx cap init panikknappen-v2 com.panikknappen.v2 --web-dir=panik-overlay
 npx cap add android
 ```
 
-Resultat: du får en Android-projektmapp där vi kan aktivera mobilbehörigheter.
+Om du redan har mappen `panik-overlay/android/` behöver du inte köra `cap add` igen.
+
+Resultat: du får (eller återanvänder) Android-projektmappen där vi kan aktivera mobilbehörigheter.
 
 ### Steg 2: Aktivera overlay + bakgrundsservice i Android
 Mål: kunna visa knapp över andra appar och hålla larmkedjan aktiv i bakgrunden.
@@ -145,11 +153,12 @@ cd panik-overlay
 npm run check
 ```
 
-Synka sedan webbbygget till Android-projektet (kör från repo-roten):
+Synka sedan webbbygget till Android-projektet (kör i `panik-overlay/`):
 
 ```bash
 # Alla plattformar
-npx cap copy android
+cd panik-overlay
+npx cap sync android
 ```
 
 ### Viktig avgränsning

--- a/panik-overlay/capacitor.config.json
+++ b/panik-overlay/capacitor.config.json
@@ -1,7 +1,5 @@
 {
   "appId": "com.github.johkahultsfred.panikknappenv2",
   "appName": "panikknappen-v2",
-  "webDir": "npm install @capacitor/androidnpx cap add android"
-
+  "webDir": "."
 }
-


### PR DESCRIPTION
### Motivation
- Undvika att Capacitor letar i fel mapp och ge nybörjare tydliga steg för Android-sync. 
- Fixa en trasig `webDir` i `panik-overlay/capacitor.config.json` som gjorde kommandon oklara. 

### Description
- Satt `webDir` i `panik-overlay/capacitor.config.json` till `.` så Capacitor läser rätt webbbygg. 
- Uppdaterat `README.md` med konkreta, copy/paste-steg att först köra `cd panik-overlay` och sedan `npx cap add android` / `npx cap sync android`. 
- Lagt till en statusnotis i README om felet `android platform has not been added yet` så felsökning blir tydligare för nybörjare. 

### Testing
- Körde `npm run check` i `panik-overlay` och det returnerade `OK: appstruktur finns` (✅). 
- Försökte köra `npx cap sync android` i `panik-overlay` men det blockerades av miljön eftersom Capacitor CLI kräver `NodeJS >=22.0.0` (⚠️). 
- Nästa enklaste steg för dig är att köra `cd panik-overlay` och sedan `npx cap sync android` på en dator med Node 22+.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bcf72fc8c8328894333e9bb963389)