### PR TITLE
docs: README — instruktion för att kopiera filer från Windows (C:) till repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Det här dokumentet är skrivet för dig som vill **bygga, testa och publicera a
 > Uppdatera den här sektionen varje gång du/agenten gör ändringar.
 
 ### Tidigare utförda aktiviteter
+- Förtydligat Windows-import (filkopiering från `C:\`) med exakt copy/paste-flöde till repo (projektmapp på GitHub) i Codex-miljön.
 - Grundstruktur för overlay finns.
 - Interaktion för drag + långtryck (5 sekunder) finns i barnappen.
 - Språkstöd (svenska/engelska) och aktiveringslogg i browser (`localStorage`) är tillagt.
@@ -168,6 +169,28 @@ npx cap sync android
 ---
 
 ## 3) Snabbstart lokalt (exakt steg-för-steg)
+
+### 3.0 Om dina filer ligger i `C:\` (Windows)
+
+Om du sitter i Codex/container (isolierad Linux-miljö) men dina filer finns i Windows, kopiera först in dem till repo-roten (huvudmappen för projektet).
+
+Kör i terminalen:
+
+```bash
+# Kör i valfri mapp (kommandot använder fulla sökvägar)
+cp -r /mnt/c/DIN/MAPP/* /workspace/PanikknappenV2/
+```
+
+Verifiera direkt efter kopiering:
+
+```bash
+# Kör i repo-roten
+cd /workspace/PanikknappenV2
+pwd
+rg --files
+```
+
+Byt `DIN/MAPP` till din riktiga Windows-sökväg (samma mappar som i `C:\...`).
 
 Kör dessa kommandon i terminalen från repo-roten (projektmapp på GitHub):
 


### PR DESCRIPTION
### Motivation
- Förtydliga för användare som jobbar i Codex/container (Linux) men har filer på Windows `C:\` så de enkelt kan flytta projektfiler in i repo:t.

### Description
- Lagt till en ny sektion `3.0 Om dina filer ligger i \`C:\\` (Windows)` i `README.md` med ett copy/paste-kommando för att kopiera filer in i repo:t: `cp -r /mnt/c/DIN/MAPP/* /workspace/PanikknappenV2/`.
- Lagt till verifieringssteg med kommandon `cd /workspace/PanikknappenV2`, `pwd` och `rg --files` så användaren snabbt ser att filerna hamnat rätt.
- Uppdaterat statusloggen i README med en rad som markerar att Windows-importen är förtydligad.

### Testing
- Kört det automatiska check-skriptet med `npm run check` i `panik-overlay/` och det lyckades med meddelandet `OK: appstruktur finns`.
- Nästa enklaste steg för dig är att köra copy/paste-kommandot i sektion 3.0 med din faktiska Windows-sökväg och sedan köra `npm run preview` i `panik-overlay/` för lokal verifiering.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d917a77a083289015a8401ce184b3)