### PR TITLE
Fixa fel badge/workflow för GitHub Pages

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,46 +1,36 @@
-name: Build Android APK
+name: GitHub Pages Deploy
 
 on:
   push:
     branches:
       - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
 
-    defaults:
-      run:
-        working-directory: panik-overlay
-
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload static site artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          node-version: 22
+          path: panik-overlay
 
-      - name: Install dependencies
-        run: npm install
-
-      - name: Sync Capacitor
-        run: npx cap sync android
-
-      - uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 17
-
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
-
-      - name: Build APK
-        run: |
-          cd android
-          chmod +x gradlew
-          ./gradlew assembleDebug
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: app-debug
-          path: panik-overlay/android/app/build/outputs/apk/debug/app-debug.apk
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Det här dokumentet är skrivet för dig som vill **bygga, testa och publicera a
 - Felsökning klar (2026-02-23): Capacitor-kommandon är nu förtydligade till `panik-overlay/`, så `android platform has not been added yet` undviks när sync körs från rätt mapp.
 - Backendkoppling klar (2026-02-24): familjelägets snabbåtgärder sparas nu via API-endpoint (`POST /api/family-actions`) i stället för enbart simulerad lokal logg.
 - Stabilisering klar (2026-02-24): backend startar nu igen efter uppdatering av `web-push`, och snabbåtgärds-API (`POST/GET /api/family-actions`) är verifierat med lokal servertest.
+- Felsökning klar (2026-02-24): `github-pages.yml` var felkopplad till Android-build, och är nu ersatt med riktig GitHub Pages-deploy så badge/länk visar rätt workflow.
 
 ### Föreslagna nästa aktiviteter
 1. Byt från testkod till riktig personlig kod per familj och lagra den säkrare (hash/krypterad variant).


### PR DESCRIPTION
### Motivation
- `github-pages.yml` var felaktigt konfigurerad och körde Android-bygg vilket gjorde att badge/länk visade fel status (workflow = arbetsflöde).
- Behövde åtgärda så att GitHub Pages-publicering använder rätt Actions-steg och publicerar innehållet från `panik-overlay` (GitHub Pages = publicera till GitHub).

### Description
- Ersatte innehållet i `.github/workflows/github-pages.yml` med ett korrekt GitHub Pages-workflow som heter `GitHub Pages Deploy` och triggas på `push` till `main` samt `workflow_dispatch` (YAML = konfigurationsformat).
- Lade till stegen `configure-pages`, `upload-pages-artifact` (med `path: panik-overlay`) och `deploy-pages` samt korrekta `permissions` för Pages.
- Uppdaterade `README.md` statusloggen med en rad som förklarar att `github-pages.yml` var felkopplad och nu är rättad.
- Commited ändringarna med meddelandet "Fixa github-pages workflow och badge-koppling" (commit = spara ändring i versionskontroll).

### Testing
- YAML-parsing kördes med `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/github-pages.yml')"` och gav `OK: yaml parse`.
- Appstrukturkontroll kördes med `cd panik-overlay && npm run check` och gav `OK: appstruktur finns`.
- `git diff --check` flaggade initialt trailing whitespace i befintliga `node_modules`-filer som inte orsakades av denna ändring, och lokala `node_modules`-ändringar rensades innan commit.
- Nästa enklaste steg för dig är att gå till `GitHub → Actions → "GitHub Pages Deploy"` och köra `Run workflow` för att verifiera att badgen visar rätt status.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699de3f289448328bd0a2642395513c3)