### PR TITLE
Fix: använd giltig Capacitor webDir och lägg till prepare-script för Android-sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Det här dokumentet är skrivet för dig som vill **bygga, testa och publicera a
 - Förtydligat (2026-02-24): om du kör i lokal Windows PowerShell ska du använda din lokala sökväg (t.ex. `C:\Users\...\PanikknappenV2`) i stället för Linux-sökvägen `/workspace/...` som bara gäller i Codex-container.
 - Uppdaterat (2026-02-24): PowerShell-exemplet pekar nu direkt på `C:\panikknappen-samlad\panik-overlay` för att matcha din aktuella lokala struktur.
 - Felsökning klar (2026-02-23): Capacitor-kommandon är nu förtydligade till `panik-overlay/`, så `android platform has not been added yet` undviks när sync körs från rätt mapp.
+- Felsökning klar (2026-02-24): Capacitor `webDir` var satt till `.` (ogiltigt i CLI v8), nu används `www` + nytt prepare-script som bygger webbfiler innan Android-sync.
 - Backendkoppling klar (2026-02-24): familjelägets snabbåtgärder sparas nu via API-endpoint (`POST /api/family-actions`) i stället för enbart simulerad lokal logg.
 - Stabilisering klar (2026-02-24): backend startar nu igen efter uppdatering av `web-push`, och snabbåtgärds-API (`POST/GET /api/family-actions`) är verifierat med lokal servertest.
 - Felsökning klar (2026-02-24): `github-pages.yml` var felkopplad till Android-build, och är nu ersatt med riktig GitHub Pages-deploy så badge/länk visar rätt workflow.
@@ -168,6 +169,13 @@ Synka sedan webbbygget till Android-projektet (kör i `panik-overlay/`):
 ```bash
 # Alla plattformar
 cd panik-overlay
+npm run cap:sync:android
+```
+
+Om du vill köra stegen separat i `panik-overlay/`:
+
+```bash
+npm run cap:prepare
 npx cap sync android
 ```
 

--- a/panik-overlay/capacitor.config.json
+++ b/panik-overlay/capacitor.config.json
@@ -1,5 +1,5 @@
 {
   "appId": "com.github.johkahultsfred.panikknappenv2",
   "appName": "panikknappen-v2",
-  "webDir": "."
+  "webDir": "www"
 }

--- a/panik-overlay/package.json
+++ b/panik-overlay/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "check": "node -e \"const fs=require('fs');['index.html','assets/css/portal.css','assets/vendor/gsap.min.js','apps/child/index.html','apps/child/style.css','apps/child/script.js','apps/family/index.html','apps/family/style.css','apps/family/script.js','assets/js/family-lock.js','server/api-server.js','data/incidents.json','data/push-subscriptions.json','data/family-actions.json'].forEach(f=>{if(!fs.existsSync(f)){throw new Error('Saknar fil: '+f)}}); console.log('OK: appstruktur finns');\"",
     "preview": "node server/api-server.js",
-    "api": "node server/api-server.js"
+    "api": "node server/api-server.js",
+    "cap:prepare": "node scripts/build-webdir.js",
+    "cap:sync:android": "npm run cap:prepare && npx cap sync android"
   },
   "dependencies": {
     "@capacitor/android": "^8.1.0",

--- a/panik-overlay/scripts/build-webdir.js
+++ b/panik-overlay/scripts/build-webdir.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+const webDir = path.join(root, 'www');
+
+const filesToCopy = ['index.html', 'manifest.webmanifest', 'sw.js'];
+const dirsToCopy = ['apps', 'assets'];
+
+fs.rmSync(webDir, { recursive: true, force: true });
+fs.mkdirSync(webDir, { recursive: true });
+
+for (const file of filesToCopy) {
+  const src = path.join(root, file);
+  const dest = path.join(webDir, file);
+  fs.copyFileSync(src, dest);
+}
+
+for (const dir of dirsToCopy) {
+  const src = path.join(root, dir);
+  const dest = path.join(webDir, dir);
+  fs.cpSync(src, dest, { recursive: true });
+}
+
+console.log('OK: www är byggd för Capacitor sync');


### PR DESCRIPTION
### Motivation
- Fixade felet `"." is not a valid value for webDir` som hindrade `npx cap sync android` från att hitta webbtillgångarna; Capacitor (verktyg för att paketera webapp som native-app) kräver en riktig mapp för `webDir` (mapp med webbtillgångar). 
- Säkerställa att Android-sync alltid får en färdig webbbyggkatalog genom ett förberedande skript så att sync inte misslyckas i CI/lokalt. 

### Description
- Ändrat `webDir` i `panik-overlay/capacitor.config.json` från `.` till `www` så Capacitor CLI v8 accepterar konfigurationen. 
- Lagt till `panik-overlay/scripts/build-webdir.js` som bygger `www/` genom att kopiera `index.html`, `manifest.webmanifest`, `sw.js`, samt katalogerna `apps/` och `assets/`. 
- Lagt till npm-skript i `panik-overlay/package.json`: `cap:prepare` (bygger `www`) och `cap:sync:android` (`npm run cap:prepare && npx cap sync android`) för enkelt copy/paste-flöde (npm-skript = kommandon). 
- Uppdaterat `README.md` med notis om felet och nya copy/paste-kommandon för sync-flödet. 

### Testing
- Kört `cd panik-overlay && npm run cap:prepare` och det lyckades och skapade `www/` (`OK: www är byggd för Capacitor sync`).
- Kört `cd panik-overlay && npm run check` för att validera att appstrukturen finns och det returnerade `OK: appstruktur finns` (succees).
- Försökt köra `npx cap sync android` men körningen stoppades av miljön eftersom Capacitor CLI kräver `Node.js (JavaScript-körmiljö) >=22.0.0` och nuvarande miljö kör Node v20, så sync kunde inte slutföras här (blockerande Node-version). 
- Nästa enklaste steg för dig är att uppgradera Node.js till 22+ och sedan köra `cd panik-overlay && npm run cap:sync:android`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699deb90c6c48328a3443706a4c551f0)