### PR TITLE
Add PAN1K KnApPen design bundle (PWA) with UI, assets placeholder and service worker

### DIFF
--- a/Goofy_design2/bundle/.gitignore
+++ b/Goofy_design2/bundle/.gitignore
@@ -1,0 +1,35 @@
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Windows
+Thumbs.db
+ehthumbs.db
+desktop.ini
+
+# Editor
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Logs
+*.log
+
+# Node (if ever needed for tooling)
+node_modules/
+npm-debug.log*
+
+# Build artifacts
+dist/
+build/
+
+# Environment
+.env
+.env.local
+
+# Lokala designbilder (binärfiler)
+assets/*.png
+!assets/.gitkeep
+!assets/README-assets.md

--- a/Goofy_design2/bundle/README.md
+++ b/Goofy_design2/bundle/README.md
@@ -1,0 +1,176 @@
+# PAN1K KnApPen!!!
+
+En mobilapp-inspirerad profilväljare för barn och tonåringar, byggd som en progressiv webbapp (PWA). Designen är pixel-for-pixel rekonstruerad från originaldesignen i PPTX/WebP-format.
+
+---
+
+> ⚠️ **Obs:** `assets/*.png` ligger inte i git i denna branch för att undvika PR-larm om binärfiler.
+> Kör kommandot nedan i repo-roten om du vill återskapa bilderna lokalt:
+>
+> ```bash
+> unzip -o Goofy_design2.zip "bundle/assets/*" -d Goofy_design2
+> ```
+
+## Skärmar
+
+| Skärm | Beskrivning |
+|---|---|
+| **Profilväljare** | Startsida med TEEN, KID och Föräldraåtkomst |
+| **PIN-pad** | 4-siffrig PIN för föräldraåtkomst (standard: `1234`) |
+| **Profil aktiv** | Bekräftelseskärm med konfetti-animation |
+| **Föräldrakontroll** | Dashboard med profilkort och inställningstoglar |
+
+---
+
+## Projektstruktur
+
+```
+panik-knappen/
+├── index.html            # App-skal, fyra skärmar
+├── manifest.json         # PWA-manifest
+├── service-worker.js     # Offline-cache (cache-first)
+├── css/
+│   └── main.css          # Komplett design-system
+├── js/
+│   └── app.js            # All interaktionslogik
+└── assets/
+    ├── image1.png        # Regnbågsstripe (top + bottom)
+    ├── image2.png        # Parental Access-pill (lila)
+    ├── image3.png        # Föräldrakaraktär (cirkel)
+    ├── image4.png        # KID-knapp (grön)
+    ├── image5.png        # KID-silhuett
+    ├── image6.png        # TEEN-knapp (orange)
+    ├── image7.png        # TEEN-silhuett
+    ├── image8.png        # Status-notch / separator
+    ├── image9.png        # Teal header-bakgrund
+    ├── image10.png       # Header blob-overlay
+    └── image11.png       # Panik-karaktär (toppvänster)
+```
+
+---
+
+## Deploy
+
+### Statisk hosting (rekommenderat)
+
+Fungerar direkt på alla statiska hostingtjänster:
+
+```bash
+# Vercel
+npx vercel --prod
+
+# Netlify
+npx netlify deploy --prod --dir .
+
+# GitHub Pages
+# Push till gh-pages branch, aktivera i repo-inställningar
+```
+
+### Lokal server (för PWA + service worker)
+
+Service workern kräver HTTPS eller `localhost`. Öppna **inte** direkt via `file://`.
+
+```bash
+# Python 3
+python3 -m http.server 8080
+
+# Node.js (npx)
+npx serve .
+
+# PHP
+php -S localhost:8080
+```
+
+Besök sedan `http://localhost:8080`.
+
+### Docker (enkel statisk server)
+
+```dockerfile
+FROM nginx:alpine
+COPY . /usr/share/nginx/html
+EXPOSE 80
+```
+
+```bash
+docker build -t panik-knappen .
+docker run -p 8080:80 panik-knappen
+```
+
+---
+
+## Design-system
+
+Alla mått är i **container query units** (`cqw` / `cqh`) relativt en `1080×1920` canvas, skalad med `aspect-ratio: 9/16`. Det innebär att layouten är identisk på alla skärmstorlekar.
+
+### Färgpaletten
+
+| Token | Hex | Användning |
+|---|---|---|
+| `--color-orange`  | `#FC7107` | TEEN-knapp, KnApPen-text |
+| `--color-teal`    | `#16B7C9` | Header-bakgrund |
+| `--color-green`   | `#C3DB33` | KID-knapp |
+| `--color-purple`  | `#8B2FC9` | Parental Access, PIN-skärm |
+| `--color-yellow`  | `#FCD30B` | Konfetti |
+| `--color-red`     | `#E63B1F` | Konfetti |
+| `--color-bg`      | `#FFFCF7` | App-bakgrund (off-white) |
+
+### Typsnitt
+
+- **Display:** Fredoka One (Google Fonts)
+- **Body/UI:** Nunito 700/800/900 (Google Fonts)
+
+---
+
+## Konfiguration
+
+### Ändra PIN-koden
+
+I `js/app.js`, rad 1 i konstantblocket:
+
+```js
+const CORRECT_PIN = '1234'; // ← Ändra här
+```
+
+### Lägg till en profil
+
+1. Lägg till ett objekt i `PROFILES` i `js/app.js`
+2. Skapa en knapp i `index.html` med `onclick="selectProfile('nytt-id')"`
+3. Lägg till assets i `assets/`
+
+### Uppdatera service worker-cache
+
+Vid ny deploy — bumpa versionen i `service-worker.js`:
+
+```js
+const CACHE_VERSION = 'panik-v1.0.1'; // ← Bumpa
+```
+
+---
+
+## Teknisk stack
+
+- **Inga ramverk** — ren HTML5, CSS3, ES2020
+- **Inga beroenden** — inga `node_modules`, ingen byggprocess
+- **PWA** — installationsbar, fungerar offline
+- **Container Queries** — responsiv utan media queries
+- **CSS Custom Properties** — design-tokens direkt i CSS
+- **Canvas API** — konfetti-burst vid profilval
+
+---
+
+## Browser-stöd
+
+| Browser | Version | Status |
+|---|---|---|
+| Chrome / Edge | 105+ | ✅ Fullt stöd |
+| Safari / iOS  | 16+  | ✅ Fullt stöd |
+| Firefox       | 110+ | ✅ Fullt stöd |
+| Samsung Internet | 20+ | ✅ Fullt stöd |
+
+Kräver stöd för CSS Container Queries (`container-type: size`).
+
+---
+
+## Ursprung
+
+Designen är extraherad och rekonstruerad från originalfiler i PPTX-format. Alla 11 PNG-assets extraherades direkt ur PPTX-arkivet (zip), och positionerna beräknades från EMU-koordinater (English Metric Units) till procent av 1080×1920-canvasen.

--- a/Goofy_design2/bundle/agents.md
+++ b/Goofy_design2/bundle/agents.md
@@ -1,0 +1,195 @@
+# agents.md — PAN1K KnApPen!!!
+
+Maskinläsbar kontext för AI-agenter (Codex, Cursor, Copilot, Claude, etc.).
+
+---
+
+## Projektöversikt
+
+**Typ:** Statisk PWA (Progressive Web App), inga ramverk, ingen byggprocess  
+**Syfte:** Mobilapp-UI profilväljare för barn/tonåringar med föräldrakontroll  
+**Canvas:** 1080×1920 (9:16), skalas via CSS `aspect-ratio` till alla skärmar  
+**Språk:** Svenska (sv)
+
+---
+
+## Filstruktur & ansvar
+
+```
+index.html          DOM-struktur, 4 skärmar, inga inline-scripts utöver SW-registrering
+css/main.css        All styling — design-tokens, layout, animationer, skärmar
+js/app.js           All logik — navigation, PIN, konfetti, profilval, canvas-animation
+service-worker.js   Cache-first offline-strategi, precache vid install
+manifest.json       PWA-metadata
+assets/image*.png   Grafiska tillgångar (PNG, RGBA, extraherade från PPTX)
+```
+
+---
+
+## Arkitekturmönster
+
+### Skärmnavigation
+
+Fyra `div.screen` med id `screen-home | screen-pin | screen-profile | screen-parental`.
+
+```
+screen-home ──[onclick showPin()]──► screen-pin ──[PIN korrekt]──► screen-parental
+     │
+     └──[onclick selectProfile(type)]──► screen-profile
+```
+
+**CSS-klasser som styr synlighet:**
+- `.hidden` — translateY(100%), opacity 0, pointer-events none (slide in from below)
+- `.slide-out-up` — translateY(-100%), opacity 0 (slide out upward)
+- (ingen klass) — synlig
+
+**JS API:**
+```js
+navigate(fromId, toId, { slideUp: false }) // intern
+goHome()                                    // publik — alltid tillgänglig
+showPin()                                   // publik — visar PIN-skärm
+selectProfile('teen' | 'kid')               // publik — visar profil-skärm
+```
+
+### Layoutsystem
+
+Alla element positioneras absolut i procent av 1080×1920:
+
+```css
+/* Formel (ex. element med left=298.5px i 1080px canvas): */
+left: calc(298.5 / 1080 * 100%); /* = 27.64% */
+top:  calc(515.4 / 1920 * 100%); /* = 26.84% */
+```
+
+Ursprungskoordinaterna kommer från PPTX EMU-systemet:
+```
+EMU → px: value / 914400 * 96
+EMU i PPTX för x: relative to slide width  (10287000 EMU = 1080px)
+EMU i PPTX för y: relative to slide height (18288000 EMU = 1920px)
+```
+
+### Typstorlekar
+
+Används `cqh` / `cqw` (container query units) relativt `.scene`:
+
+```css
+font-size: 8.5cqh;  /* 8.5% av scene-höjden */
+font-size: 6.5cqh;  /* etc. */
+```
+
+---
+
+## State
+
+All state är modul-scoped i `js/app.js`. Ingen extern lagring.
+
+```js
+let pinBuffer    = '';   // String, 0–4 siffror
+let wrongTries   = 0;    // Number, ökar vid fel PIN
+let currentScreen = 'screen-home'; // String, aktuell skärm-id
+```
+
+---
+
+## Assets
+
+| Fil | Storlek | Innehåll | Används av |
+|---|---|---|---|
+| `image1.png`  | 188KB | Regnbågsstripe (1268×149) | Top + bottom stripe, alla skärmar |
+| `image2.png`  | 103KB | Lila pill-knapp (498×178) | Parental Access-knapp |
+| `image3.png`  |  81KB | Föräldrakaraktär cirkel (265×272) | Parental char + PIN-header + parental-dash |
+| `image4.png`  | 203KB | Grön KID-knapp (514×334) | KID-knapp |
+| `image5.png`  |  60KB | KID-silhuett (218×360) | KID-karaktär |
+| `image6.png`  |  86KB | Orange TEEN-knapp (356×224) | TEEN-knapp |
+| `image7.png`  |  59KB | TEEN-silhuett (259×335) | TEEN-karaktär + profil-screen + parental-card |
+| `image8.png`  |  15KB | Status notch/separator (653×46) | Notch + separator-linje |
+| `image9.png`  |  71KB | Teal header-bakgrund (853×193) | Header base + profil-screen header |
+| `image10.png` | 194KB | Colorful blob-overlay (2134×750) | Header overlay (118% bredd, clip via overflow) |
+| `image11.png` | ~200KB | Panik-karaktär (1213×1066, fixed) | Top-left hero |
+
+**OBS:** `image11.png` har modifierats — övre 160px transparenta (Canva-artefakt "ICONS" borttagen).
+
+---
+
+## Konfetti-system
+
+`initConfetti(containerId, count)` skapar `<div>`-element med CSS-animationer:
+
+- **Former:** `pill-h`, `pill-v`, `dot`, `square`
+- **Färger:** `#FC7107 #16B7C9 #C3DB33 #8B2FC9 #FCD30B #E63B1F #FC81CF #ffffff`
+- **Animationer:** `fall` (vertikal, linjär, loop) + `wobble` (horisontell sinusvåg)
+- **Enheter:** `cqw` / `cqh` — skalrar med canvas
+
+Celebration burst vid profilval sker via Canvas 2D API i `launchCelebration(color)`.
+
+---
+
+## Utbyggnadspunkter
+
+### Lägg till profil
+```js
+// js/app.js — PROFILES-objektet
+PROFILES['junior'] = {
+  label:       'JUNIOR',
+  sub:         'Profil 3 · Aktiv',
+  accentColor: '#8B2FC9',
+  ringColor:   '#8B2FC9',
+  badgeBg:     '#8B2FC9',
+  charSelector: '.anim-junior .char img',
+};
+```
+
+```html
+<!-- index.html — ny knappgrupp i screen-home -->
+<div class="anim-junior" style="...">
+  <div class="btn-wrap" onclick="selectProfile('junior')">
+    <img src="assets/image-junior-btn.png" alt="JUNIOR">
+  </div>
+</div>
+```
+
+### Persistent PIN (localStorage)
+```js
+// Ersätt konstanten med:
+const CORRECT_PIN = localStorage.getItem('parentPin') ?? '1234';
+
+// Spara ny PIN:
+localStorage.setItem('parentPin', newPin);
+```
+
+### Ändra PIN via UI
+Implementera en ny skärm `screen-change-pin` med dubbel PIN-verifikation. Länka från "Ändra PIN-kod"-raden i parental dashboard.
+
+### Analytics/telemetri
+`selectProfile()` och `showPin()` är centrala hooks — lägg in tracking-anrop där.
+
+---
+
+## Kodkonventioner
+
+- `'use strict'` i app.js
+- Inga globala variabler utom de som exponeras via `Object.assign(window, {...})`
+- `const` > `let`, aldrig `var`
+- Funktioner namnges med camelCase verbform: `selectProfile`, `showPin`, `goHome`
+- CSS-klasser: kebab-case, BEM-inspirerat (`.profile-card`, `.profile-card-name`)
+- Inga kommentarer på rad, bara block-kommentarer för sektioner
+
+---
+
+## Testning
+
+Ingen testsvit är inkluderad. För manuell testning:
+
+1. Starta lokal server: `python3 -m http.server 8080`
+2. Öppna `http://localhost:8080` i Chrome DevTools med device emulation (9:16)
+3. Flöde: Hem → TEEN/KID → Profil aktiv → Tillbaka → Parental Access → PIN `1234` → Dashboard
+
+**Snapshot-test med Playwright:**
+```js
+const { chromium } = require('playwright');
+const browser = await chromium.launch();
+const page = await browser.newPage();
+await page.setViewportSize({ width: 432, height: 768 });
+await page.goto('http://localhost:8080');
+await page.screenshot({ path: 'snapshot-home.png' });
+```

--- a/Goofy_design2/bundle/assets/README-assets.md
+++ b/Goofy_design2/bundle/assets/README-assets.md
@@ -1,0 +1,12 @@
+# Assets (bilder) – lokalt tillägg
+
+Den här mappen är medvetet tom i git för att undvika larm om binärfiler i PR (ändringsförslag).
+
+## Lägg tillbaka bilder lokalt
+Kör i repo-roten (mappen där `Goofy_design2.zip` ligger):
+
+```bash
+unzip -o Goofy_design2.zip "bundle/assets/*" -d Goofy_design2
+```
+
+Efter kommandot ska filer som `Goofy_design2/bundle/assets/image1.png` finnas lokalt.

--- a/Goofy_design2/bundle/css/main.css
+++ b/Goofy_design2/bundle/css/main.css
@@ -1,0 +1,419 @@
+/* ═══════════════════════════════════════════════════════════════
+   PAN1K KnApPen!!! — main.css
+   Design system: 1080×1920 canvas, scaled with CSS aspect-ratio
+   All internal units: cqw / cqh (container query units)
+═══════════════════════════════════════════════════════════════ */
+
+/* ── Reset ── */
+*, *::before, *::after {
+  margin: 0; padding: 0;
+  box-sizing: border-box;
+}
+
+/* ── CSS custom properties (design tokens) ── */
+:root {
+  --color-orange:  #FC7107;
+  --color-teal:    #16B7C9;
+  --color-green:   #C3DB33;
+  --color-purple:  #8B2FC9;
+  --color-yellow:  #FCD30B;
+  --color-red:     #E63B1F;
+  --color-pink:    #FC81CF;
+  --color-bg:      #FFFCF7;
+  --color-dark:    #0d0d0d;
+
+  --font-display: 'Fredoka One', Impact, sans-serif;
+  --font-body:    'Nunito', system-ui, sans-serif;
+
+  /* Spring easing */
+  --spring:       cubic-bezier(.34, 1.56, .64, 1);
+  --ease-screen:  cubic-bezier(.77,  0,   .18, 1);
+}
+
+/* ── App shell ── */
+html, body {
+  width: 100%; height: 100%;
+  background: radial-gradient(ellipse at 50% 30%, #1a2a4a 0%, #0a0a14 70%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  font-family: var(--font-display);
+}
+
+/* ── Scene: the 9:16 "phone" canvas ── */
+.scene {
+  position: relative;
+  width: min(100vw, calc(100vh * 0.5625));
+  aspect-ratio: 9 / 16;
+  background: var(--color-bg);
+  overflow: hidden;
+  container-type: size;
+  box-shadow:
+    0 0 0 1px rgba(255,255,255,.08),
+    0 8px 60px rgba(0,0,0,.7),
+    0 2px 12px rgba(0,0,0,.5);
+  border-radius: 12px;
+}
+
+/* ── Screen transitions ── */
+.screen {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  transition:
+    transform .45s var(--ease-screen),
+    opacity   .35s ease;
+}
+.screen.hidden {
+  transform: translateY(100%);
+  opacity: 0;
+  pointer-events: none;
+}
+.screen.slide-out-up {
+  transform: translateY(-100%);
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* ── Absolute layer helper ── */
+.l {
+  position: absolute;
+  display: block;
+}
+img.l { object-fit: fill; }
+
+/* ── Confetti layer ── */
+.confetti-layer {
+  position: absolute; inset: 0;
+  pointer-events: none;
+  z-index: 6;
+  overflow: hidden;
+}
+
+/* ── Entrance animations ── */
+@keyframes dropIn {
+  from { transform: translateY(-8%) rotate(-3deg); opacity: 0; }
+  70%  { transform: translateY(1%)  rotate(.5deg);  opacity: 1; }
+  to   { transform: translateY(0)   rotate(0);      opacity: 1; }
+}
+@keyframes bounceIn {
+  0%  { transform: scale(.6) translateY(5%); opacity: 0; }
+  60% { transform: scale(1.06) translateY(0); opacity: 1; }
+  80% { transform: scale(.97); }
+  to  { transform: scale(1); }
+}
+
+.anim-header { animation: dropIn   .70s var(--spring) .10s both; }
+.anim-teen   { animation: bounceIn .65s var(--spring) .25s both; }
+.anim-kid    { animation: bounceIn .65s var(--spring) .40s both; }
+.anim-parent { animation: bounceIn .65s var(--spring) .55s both; }
+
+/* ── Floating character animation ── */
+@keyframes bob {
+  0%, 100% { transform: translateY(0)    rotate(0deg);   }
+  40%       { transform: translateY(-2.2%) rotate(-.6deg); }
+  60%       { transform: translateY(-1.8%) rotate(.4deg);  }
+}
+.char {
+  position: absolute;
+  animation: bob var(--d, 3s) ease-in-out infinite var(--dl, 0s);
+  pointer-events: none;
+}
+.char img { width: 100%; height: 100%; object-fit: fill; }
+
+/* ── Button groups ── */
+.btn-wrap {
+  position: absolute;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  transform-origin: center center;
+  transition:
+    transform .12s var(--spring),
+    filter    .10s ease;
+}
+.btn-wrap:hover  { transform: scale(1.04) translateY(-.5%); }
+.btn-wrap:active { transform: scale(.94) translateY(1%); filter: brightness(.92); }
+.btn-wrap img    { width: 100%; height: 100%; object-fit: fill; display: block; }
+
+/* ── Text overlays ── */
+.pan1k {
+  position: absolute; z-index: 15;
+  font-family: var(--font-display);
+  color: #fff;
+  text-shadow:
+     3px  3px 0 var(--color-dark), -1px  3px 0 var(--color-dark),
+     3px -1px 0 var(--color-dark), -1px -1px 0 var(--color-dark),
+     0 4px 18px rgba(0,0,0,.3);
+  line-height: .9;
+  letter-spacing: -1px;
+  font-size: 8.5cqh;
+  display: flex; align-items: center;
+  pointer-events: none;
+}
+.knappen {
+  position: absolute; z-index: 15;
+  font-family: var(--font-display);
+  color: var(--color-orange);
+  text-shadow: 2px 2px 0 var(--color-dark), -1px 2px 0 var(--color-dark);
+  line-height: 1;
+  letter-spacing: 1.5px;
+  font-size: 6.5cqh;
+  display: flex; align-items: center;
+  pointer-events: none;
+}
+
+/* ══════════════════════════════════════
+   SCREEN 2 — PIN PAD
+══════════════════════════════════════ */
+#screen-pin {
+  background: var(--color-bg);
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+}
+
+.pin-header {
+  width: 100%;
+  background: var(--color-purple);
+  padding: 4cqh 5cqw;
+  display: flex; align-items: center; gap: 3cqw;
+  position: absolute; top: 0; left: 0;
+}
+.pin-back {
+  background: rgba(255,255,255,.25);
+  border: none; border-radius: 50%;
+  width: 8cqw; height: 8cqw;
+  cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 4cqw; color: #fff;
+  flex-shrink: 0;
+  transition: background .15s;
+}
+.pin-back:hover { background: rgba(255,255,255,.4); }
+.pin-title {
+  font-family: var(--font-display);
+  color: #fff; font-size: 5cqw; letter-spacing: .5px;
+}
+.pin-parent-img {
+  position: absolute; right: 4cqw; top: 1.5cqh;
+  width: 13cqw; height: 16cqw;
+  object-fit: fill; opacity: .9;
+}
+
+.pin-body {
+  display: flex; flex-direction: column;
+  align-items: center; gap: 2.5cqh;
+  padding-top: 22cqh;
+}
+.pin-label {
+  font-family: var(--font-body); font-weight: 800;
+  color: #555; font-size: 3.2cqw;
+  letter-spacing: .5px; text-transform: uppercase;
+}
+.pin-dots { display: flex; gap: 4.5cqw; }
+.pin-dot {
+  width: 5.5cqw; height: 5.5cqw; border-radius: 50%;
+  border: 2.5px solid var(--color-purple);
+  background: transparent;
+  transition: background .2s, transform .15s var(--spring);
+}
+.pin-dot.filled { background: var(--color-purple); transform: scale(1.2); }
+
+@keyframes shake {
+  0%, 100% { transform: translateX(0); }
+  20% { transform: translateX(-4cqw); }
+  40% { transform: translateX( 4cqw); }
+  60% { transform: translateX(-3cqw); }
+  80% { transform: translateX( 3cqw); }
+}
+.pin-dots.error { animation: shake .4s ease; }
+
+.pin-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 3cqw; width: 72cqw;
+}
+.pin-key {
+  aspect-ratio: 1; border-radius: 50%; border: none;
+  background: #F0EDE8;
+  font-family: var(--font-display); font-size: 6cqw; color: #333;
+  cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  transition:
+    transform .10s var(--spring),
+    background .10s,
+    box-shadow .10s;
+  box-shadow: 0 3px 0 #d0cdc8;
+}
+.pin-key:hover  { background: #E8E4DE; transform: scale(1.05); }
+.pin-key:active { transform: scale(.92) translateY(2px); box-shadow: 0 1px 0 #d0cdc8; }
+.pin-key.special { background: var(--color-purple); color: #fff; box-shadow: 0 3px 0 #6a1fa0; }
+.pin-key.special:active { box-shadow: 0 1px 0 #6a1fa0; }
+.pin-key.delete  { background: #FFE8E0; color: var(--color-orange); box-shadow: 0 3px 0 #e8c8b8; }
+
+.pin-error-msg {
+  font-family: var(--font-body); font-weight: 700;
+  color: var(--color-red); font-size: 3cqw;
+  height: 3.5cqw; opacity: 0;
+  transition: opacity .2s;
+}
+.pin-error-msg.visible { opacity: 1; }
+
+/* ══════════════════════════════════════
+   SCREEN 3 — PROFILE ACTIVE
+══════════════════════════════════════ */
+#screen-profile {
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: flex-start;
+  overflow: hidden;
+}
+.profile-header {
+  width: 100%; height: 22cqh; position: relative;
+  display: flex; align-items: flex-end; justify-content: center;
+  padding-bottom: 2cqh;
+}
+.profile-bg-strip {
+  position: absolute; inset: 0;
+  object-fit: fill; width: 100%; height: 100%;
+}
+.profile-back {
+  position: absolute; left: 4cqw; bottom: 2cqh;
+  background: rgba(255,255,255,.25); border: none; border-radius: 50%;
+  width: 9cqw; height: 9cqw; cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 4.5cqw; color: #fff; z-index: 10;
+  transition: background .15s;
+}
+.profile-back:hover { background: rgba(255,255,255,.4); }
+.profile-tag {
+  font-family: var(--font-display); color: #fff;
+  font-size: 7cqw; text-shadow: 2px 2px 0 rgba(0,0,0,.3);
+  letter-spacing: 1px; z-index: 10;
+}
+.profile-char-wrap {
+  width: 55cqw; aspect-ratio: 1;
+  margin-top: 4cqh; position: relative;
+  display: flex; align-items: center; justify-content: center;
+}
+.profile-char-bg { position: absolute; inset: 0; border-radius: 50%; opacity: .15; }
+.profile-char    { width: 90%; height: 90%; object-fit: contain; animation: bob 2.5s ease-in-out infinite; }
+
+@keyframes pulse-ring {
+  0%   { transform: scale(1);   opacity: .5; }
+  100% { transform: scale(1.4); opacity: 0;  }
+}
+.profile-ring {
+  position: absolute; inset: 0; border-radius: 50%;
+  border: 3px solid;
+  animation: pulse-ring 1.8s ease-out infinite;
+}
+.profile-name {
+  font-family: var(--font-display); font-size: 8cqw;
+  letter-spacing: 2px; margin-top: 2cqh;
+}
+.profile-sub {
+  font-family: var(--font-body); font-weight: 700;
+  font-size: 3cqw; color: #888;
+  letter-spacing: 2px; text-transform: uppercase; margin-top: .5cqh;
+}
+@keyframes celebrate {
+  0%  { transform: scale(0) rotate(-20deg); opacity: 0; }
+  60% { transform: scale(1.15) rotate(3deg); opacity: 1; }
+  80% { transform: scale(.95); }
+  to  { transform: scale(1) rotate(0); }
+}
+.profile-badge {
+  margin-top: 3cqh; padding: 1.5cqh 6cqw; border-radius: 50px;
+  font-family: var(--font-display); font-size: 4cqw; color: #fff;
+  text-shadow: 1px 1px 0 rgba(0,0,0,.2);
+  animation: celebrate .6s var(--spring) .3s both;
+  cursor: pointer; border: none;
+  transition: transform .12s var(--spring), filter .1s;
+}
+.profile-badge:hover  { transform: scale(1.05); }
+.profile-badge:active { transform: scale(.95); filter: brightness(.9); }
+
+.profile-confetti-canvas {
+  position: absolute; inset: 0;
+  pointer-events: none; z-index: 20;
+}
+
+/* ══════════════════════════════════════
+   SCREEN 4 — PARENTAL DASHBOARD
+══════════════════════════════════════ */
+#screen-parental { background: var(--color-bg); display: flex; flex-direction: column; }
+
+.parental-header {
+  background: var(--color-purple);
+  padding: 4cqh 5cqw 3cqh;
+  display: flex; align-items: center; gap: 3cqw; position: relative;
+}
+.parental-title {
+  font-family: var(--font-display); color: #fff; font-size: 5.5cqw; letter-spacing: .5px;
+}
+.parental-body {
+  flex: 1; padding: 3cqh 5cqw;
+  display: flex; flex-direction: column; gap: 2.5cqh;
+  overflow-y: auto;
+}
+.parental-section-title {
+  font-family: var(--font-body); font-weight: 900;
+  font-size: 3cqw; color: #999; text-transform: uppercase; letter-spacing: 1.5px;
+  margin-top: 1cqh;
+}
+.profile-card {
+  background: #fff; border-radius: 4cqw;
+  padding: 3cqw 4cqw;
+  display: flex; align-items: center; gap: 3cqw;
+  box-shadow: 0 2px 12px rgba(0,0,0,.07);
+  border: 2px solid transparent;
+  transition: box-shadow .2s;
+  cursor: pointer;
+}
+.profile-card:hover { box-shadow: 0 4px 20px rgba(0,0,0,.13); }
+.profile-card-icon {
+  width: 12cqw; height: 12cqw; border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  flex-shrink: 0; overflow: hidden;
+}
+.profile-card-icon img { width: 85%; height: 85%; object-fit: contain; }
+.profile-card-text   { flex: 1; }
+.profile-card-name   { font-family: var(--font-display); font-size: 4.5cqw; color: #333; line-height: 1.1; }
+.profile-card-desc   { font-family: var(--font-body); font-weight: 700; font-size: 2.8cqw; color: #aaa; margin-top: .5cqw; }
+.profile-card-arrow  { font-size: 4cqw; color: #ccc; }
+
+.time-limit-row {
+  display: flex; align-items: center; gap: 3cqw;
+  background: #fff; border-radius: 4cqw;
+  padding: 3cqw 4cqw;
+  box-shadow: 0 2px 12px rgba(0,0,0,.07);
+}
+.time-icon  { font-size: 5cqw; flex-shrink: 0; }
+.time-label { font-family: var(--font-body); font-weight: 800; font-size: 3.5cqw; color: #333; flex: 1; }
+.time-toggle {
+  width: 11cqw; height: 6cqw; border-radius: 3cqw;
+  background: #ddd; position: relative; cursor: pointer;
+  border: none; padding: 0; flex-shrink: 0;
+  transition: background .25s;
+}
+.time-toggle.on { background: var(--color-purple); }
+.time-toggle::after {
+  content: ''; position: absolute;
+  width: 5cqw; height: 5cqw; border-radius: 50%;
+  background: #fff; top: .5cqw; left: .5cqw;
+  transition: left .25s var(--spring);
+  box-shadow: 0 1px 4px rgba(0,0,0,.2);
+}
+.time-toggle.on::after { left: 5.5cqw; }
+
+/* ── Confetti candy (falling particles) ── */
+@keyframes fall {
+  0%   { transform: translateY(0)      rotate(var(--r0)) scaleX(var(--sx)); opacity: .88; }
+  80%  { opacity: .88; }
+  100% { transform: translateY(110cqh) rotate(var(--r1)) scaleX(var(--sx)); opacity: 0; }
+}
+@keyframes wobble {
+  0%   { transform: translateX(0); }
+  25%  { transform: translateX(var(--wx)); }
+  75%  { transform: translateX(calc(-1 * var(--wx))); }
+  100% { transform: translateX(0); }
+}

--- a/Goofy_design2/bundle/index.html
+++ b/Goofy_design2/bundle/index.html
@@ -1,0 +1,289 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no">
+  <meta name="theme-color" content="#16B7C9">
+  <meta name="description" content="PAN1K KnApPen!!! – profilväljare för barn och tonåringar">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+
+  <title>PAN1K KnApPen!!!</title>
+
+  <link rel="manifest" href="manifest.json">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet"
+    href="https://fonts.googleapis.com/css2?family=Fredoka+One&family=Nunito:wght@700;800;900&display=swap">
+  <link rel="stylesheet" href="css/main.css">
+</head>
+<body>
+<div class="scene">
+
+<!-- ╔══════════════════════════════════════╗
+     ║   SCREEN 1 — PROFILE SELECTOR      ║
+     ╚══════════════════════════════════════╝ -->
+<div id="screen-home" class="screen">
+
+  <!-- Static base layers -->
+  <img class="l" style="left:0;top:0;width:100%;height:19.91%;z-index:1"
+       src="assets/image9.png" alt="">
+  <img class="l" style="left:0;top:0;width:100%;height:6.61%;z-index:2"
+       src="assets/image1.png" alt="">
+  <img class="l" style="left:-0.15%;top:-1.54%;width:118.38%;height:23.39%;z-index:3"
+       src="assets/image10.png" alt="">
+
+  <!-- Panic character (header) -->
+  <div class="anim-header" style="position:absolute;inset:0;pointer-events:none;z-index:4">
+    <img class="l char"
+         style="left:-1.3%;top:-2.06%;width:61.28%;height:25.56%;z-index:4;--d:2.8s;--dl:.3s"
+         src="assets/image11.png" alt="Panic character">
+  </div>
+
+  <!-- Phone status notch -->
+  <img class="l" style="left:30%;top:-0.52%;width:40%;height:1.54%;z-index:6;opacity:.8"
+       src="assets/image8.png" alt="">
+
+  <!-- Title texts -->
+  <div class="pan1k anim-header"
+       style="left:10.96%;top:1.53%;width:58.04%;height:11.2%">PAN1K</div>
+  <div class="knappen anim-header"
+       style="left:21.62%;top:9.57%;width:74.75%;height:8.27%">KnApPen!!!</div>
+
+  <!-- Separator line -->
+  <img class="l" style="left:41.2%;top:19.57%;width:17.59%;height:0.68%;z-index:5;opacity:.4"
+       src="assets/image8.png" alt="">
+
+  <!-- Decorative dots (from original design) -->
+  <div class="l" style="left:52.5%;top:16.2%;width:1.2%;aspect-ratio:1;background:#16B7C9;border-radius:50%;z-index:6"></div>
+  <div class="l" style="left:85%;top:19.2%;width:0.9%;aspect-ratio:1;background:#9C27B0;border-radius:50%;z-index:6"></div>
+  <div class="l" style="left:88%;top:38%;width:0.7%;aspect-ratio:1;background:#FC7107;border-radius:50%;z-index:7"></div>
+
+  <!-- ── TEEN button (Group 12) ───────────────── -->
+  <div class="anim-teen" style="position:absolute;left:0;top:0;width:100%;height:100%;pointer-events:none">
+    <div class="btn-wrap"
+         style="left:27.64%;top:26.84%;width:80.88%;height:28.63%;z-index:10;pointer-events:all"
+         onclick="selectProfile('teen')" role="button" aria-label="Välj TEEN-profil">
+      <img src="assets/image6.png" alt="TEEN Profile 1">
+    </div>
+    <div class="char" style="position:absolute;left:10%;top:21.68%;width:31.59%;height:22.99%;z-index:11;--d:3.2s">
+      <img src="assets/image7.png" alt="">
+    </div>
+  </div>
+
+  <!-- ── KID button (Group 9) ─────────────────── -->
+  <div class="anim-kid" style="position:absolute;left:0;top:0;width:100%;height:100%;pointer-events:none">
+    <div class="btn-wrap"
+         style="left:28.38%;top:54.38%;width:79.19%;height:28.94%;z-index:10;pointer-events:all"
+         onclick="selectProfile('kid')" role="button" aria-label="Välj KID-profil">
+      <img src="assets/image4.png" alt="KID Profile 2">
+    </div>
+    <div class="char" style="position:absolute;left:10.57%;top:47.02%;width:32.77%;height:30.44%;z-index:11;--d:3.8s;--dl:.6s">
+      <img src="assets/image5.png" alt="">
+    </div>
+  </div>
+
+  <!-- ── Parental Access (Group 6) ────────────── -->
+  <div class="anim-parent" style="position:absolute;left:0;top:0;width:100%;height:100%;pointer-events:none">
+    <div class="btn-wrap"
+         style="left:41.21%;top:80.72%;width:64.71%;height:12.85%;z-index:10;pointer-events:all"
+         onclick="showPin()" role="button" aria-label="Föräldraåtkomst">
+      <img src="assets/image2.png" alt="Parental Access">
+    </div>
+    <div class="char" style="position:absolute;left:15.54%;top:77.19%;width:27.19%;height:17.67%;z-index:11;--d:2.5s;--dl:1.1s">
+      <img src="assets/image3.png" alt="">
+    </div>
+  </div>
+
+  <!-- Falling confetti -->
+  <div class="confetti-layer" id="confetti-home"></div>
+
+  <!-- Bottom rainbow stripe -->
+  <img class="l" style="left:-0.47%;top:93.39%;width:100.47%;height:6.61%;z-index:2"
+       src="assets/image1.png" alt="">
+
+</div><!-- /screen-home -->
+
+
+<!-- ╔══════════════════════════════════════╗
+     ║   SCREEN 2 — PIN PAD               ║
+     ╚══════════════════════════════════════╝ -->
+<div id="screen-pin" class="screen hidden">
+
+  <!-- Rainbow stripe top -->
+  <img style="position:absolute;left:0;top:0;width:100%;height:6.61%;z-index:2;object-fit:fill"
+       src="assets/image1.png" alt="">
+
+  <!-- Purple header -->
+  <div class="pin-header" style="padding-top:7cqh">
+    <button class="pin-back" onclick="goHome()" aria-label="Tillbaka">←</button>
+    <div class="pin-title">Föräldraåtkomst</div>
+    <img class="pin-parent-img" src="assets/image3.png" alt="">
+  </div>
+
+  <div class="pin-body">
+    <div class="pin-label">Ange PIN-kod</div>
+
+    <div class="pin-dots" id="pin-dots" role="group" aria-label="PIN-inmatning">
+      <div class="pin-dot" id="pd0"></div>
+      <div class="pin-dot" id="pd1"></div>
+      <div class="pin-dot" id="pd2"></div>
+      <div class="pin-dot" id="pd3"></div>
+    </div>
+
+    <div class="pin-error-msg" id="pin-error" role="alert">Fel PIN-kod. Försök igen.</div>
+
+    <div class="pin-grid" role="group" aria-label="Sifferknappar">
+      <button class="pin-key" onclick="pinPress('1')" aria-label="1">1</button>
+      <button class="pin-key" onclick="pinPress('2')" aria-label="2">2</button>
+      <button class="pin-key" onclick="pinPress('3')" aria-label="3">3</button>
+      <button class="pin-key" onclick="pinPress('4')" aria-label="4">4</button>
+      <button class="pin-key" onclick="pinPress('5')" aria-label="5">5</button>
+      <button class="pin-key" onclick="pinPress('6')" aria-label="6">6</button>
+      <button class="pin-key" onclick="pinPress('7')" aria-label="7">7</button>
+      <button class="pin-key" onclick="pinPress('8')" aria-label="8">8</button>
+      <button class="pin-key" onclick="pinPress('9')" aria-label="9">9</button>
+      <button class="pin-key special" onclick="pinPress('ok')"
+              style="font-size:3cqw;letter-spacing:.5px" aria-label="OK">OK</button>
+      <button class="pin-key" onclick="pinPress('0')" aria-label="0">0</button>
+      <button class="pin-key delete" onclick="pinPress('del')" aria-label="Radera">⌫</button>
+    </div>
+
+    <div id="pin-hint"
+         style="font-family:'Nunito',sans-serif;font-size:2.8cqw;color:#bbb;margin-top:1cqh;display:none">
+      Tips: PIN är <strong style="color:#aaa">1234</strong>
+    </div>
+  </div>
+
+  <!-- Bottom rainbow stripe -->
+  <img style="position:absolute;left:-0.47%;top:93.39%;width:100.47%;height:6.61%;z-index:2;object-fit:fill"
+       src="assets/image1.png" alt="">
+
+</div><!-- /screen-pin -->
+
+
+<!-- ╔══════════════════════════════════════╗
+     ║   SCREEN 3 — PROFILE ACTIVE        ║
+     ╚══════════════════════════════════════╝ -->
+<div id="screen-profile" class="screen hidden">
+
+  <div class="profile-header">
+    <img class="profile-bg-strip" id="profile-header-img" src="assets/image9.png" alt="">
+    <img style="position:absolute;left:0;top:0;width:100%;height:30%;z-index:3;object-fit:fill;opacity:.9"
+         src="assets/image1.png" alt="">
+    <button class="profile-back" onclick="goHome()" aria-label="Tillbaka">←</button>
+    <div class="profile-tag" id="profile-tag">TEEN</div>
+  </div>
+
+  <div class="profile-char-wrap">
+    <div class="profile-char-bg" id="profile-char-bg"></div>
+    <div class="profile-ring"    id="profile-ring"></div>
+    <img class="profile-char"   id="profile-char-img" src="assets/image7.png" alt="Karaktär">
+  </div>
+
+  <div class="profile-name" id="profile-name">TEEN</div>
+  <div class="profile-sub"  id="profile-sub">Profil 1 · Aktiv</div>
+
+  <button class="profile-badge" id="profile-badge" onclick="goHome()">
+    ✓ &nbsp;Byt profil
+  </button>
+
+  <canvas class="profile-confetti-canvas" id="celebrate-canvas"></canvas>
+
+  <!-- Bottom rainbow stripe -->
+  <img style="position:absolute;left:-0.47%;top:93.39%;width:100.47%;height:6.61%;z-index:2;object-fit:fill"
+       src="assets/image1.png" alt="">
+
+</div><!-- /screen-profile -->
+
+
+<!-- ╔══════════════════════════════════════╗
+     ║   SCREEN 4 — PARENTAL DASHBOARD    ║
+     ╚══════════════════════════════════════╝ -->
+<div id="screen-parental" class="screen hidden">
+
+  <!-- Rainbow stripe top -->
+  <img style="position:absolute;left:0;top:0;width:100%;height:6.61%;z-index:5;object-fit:fill"
+       src="assets/image1.png" alt="">
+
+  <div class="parental-header" style="padding-top:7cqh">
+    <button class="pin-back" onclick="goHome()" aria-label="Tillbaka">←</button>
+    <div class="parental-title">Föräldrakontroll</div>
+    <img style="position:absolute;right:4cqw;top:1.5cqh;width:13cqw;height:16cqw;object-fit:fill;opacity:.85"
+         src="assets/image3.png" alt="">
+  </div>
+
+  <div class="parental-body">
+    <div class="parental-section-title">Profiler</div>
+
+    <div class="profile-card" style="border-color:rgba(252,113,7,.3)">
+      <div class="profile-card-icon" style="background:rgba(252,113,7,.12)">
+        <img src="assets/image7.png" alt="">
+      </div>
+      <div class="profile-card-text">
+        <div class="profile-card-name" style="color:#FC7107">TEEN</div>
+        <div class="profile-card-desc">Profil 1 · Ålder 13–17</div>
+      </div>
+      <div class="profile-card-arrow">›</div>
+    </div>
+
+    <div class="profile-card" style="border-color:rgba(195,219,51,.5)">
+      <div class="profile-card-icon" style="background:rgba(195,219,51,.2)">
+        <img src="assets/image5.png" alt="">
+      </div>
+      <div class="profile-card-text">
+        <div class="profile-card-name" style="color:#7a9a00">KID</div>
+        <div class="profile-card-desc">Profil 2 · Ålder 6–12</div>
+      </div>
+      <div class="profile-card-arrow">›</div>
+    </div>
+
+    <div class="parental-section-title" style="margin-top:.5cqh">Tidsgränser</div>
+
+    <div class="time-limit-row">
+      <span class="time-icon">⏱</span>
+      <span class="time-label">Daglig tidsgräns</span>
+      <button class="time-toggle on" id="toggle-time"
+              onclick="toggleSwitch('toggle-time')" aria-label="Daglig tidsgräns"></button>
+    </div>
+    <div class="time-limit-row">
+      <span class="time-icon">🔔</span>
+      <span class="time-label">Aviseringar</span>
+      <button class="time-toggle on" id="toggle-notif"
+              onclick="toggleSwitch('toggle-notif')" aria-label="Aviseringar"></button>
+    </div>
+    <div class="time-limit-row">
+      <span class="time-icon">🔒</span>
+      <span class="time-label">Innehållsfilter</span>
+      <button class="time-toggle on" id="toggle-filter"
+              onclick="toggleSwitch('toggle-filter')" aria-label="Innehållsfilter"></button>
+    </div>
+
+    <div class="parental-section-title" style="margin-top:.5cqh">Säkerhet</div>
+    <div class="time-limit-row" style="cursor:pointer" onclick="alert('Funktionen är inte implementerad ännu.')">
+      <span class="time-icon">🔑</span>
+      <span class="time-label">Ändra PIN-kod</span>
+      <span style="font-size:4cqw;color:#ccc">›</span>
+    </div>
+  </div>
+
+  <!-- Bottom rainbow stripe -->
+  <img style="position:absolute;left:-0.47%;top:93.39%;width:100.47%;height:6.61%;z-index:2;object-fit:fill"
+       src="assets/image1.png" alt="">
+
+</div><!-- /screen-parental -->
+
+</div><!-- /scene -->
+
+<script src="js/app.js"></script>
+<script>
+  // Register service worker for PWA / offline support
+  if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+      navigator.serviceWorker.register('/service-worker.js')
+        .catch(() => {}); // Fail silently in file:// context
+    });
+  }
+</script>
+</body>
+</html>

--- a/Goofy_design2/bundle/js/app.js
+++ b/Goofy_design2/bundle/js/app.js
@@ -1,0 +1,305 @@
+/**
+ * PAN1K KnApPen!!! — app.js
+ * Handles: confetti, navigation, PIN, profile selection, celebration burst.
+ *
+ * Architecture: single-page, 4 screens, no framework, no build step.
+ * All state lives in module-scoped variables — no localStorage (privacy).
+ */
+
+'use strict';
+
+/* ═══════════════════════════════════════════════════════════════
+   CONSTANTS
+═══════════════════════════════════════════════════════════════ */
+const CORRECT_PIN = '1234';
+
+const CANDY_COLORS = [
+  '#FC7107', // orange
+  '#16B7C9', // teal
+  '#C3DB33', // green
+  '#8B2FC9', // purple
+  '#FCD30B', // yellow
+  '#E63B1F', // red
+  '#FC81CF', // pink
+  '#ffffff',  // white
+];
+
+const CANDY_SHAPES = ['pill-h', 'pill-v', 'dot', 'square'];
+
+const PROFILES = {
+  teen: {
+    label:      'TEEN',
+    sub:        'Profil 1 · Aktiv',
+    accentColor: '#FC7107',
+    ringColor:   '#FC7107',
+    badgeBg:     '#FC7107',
+    charSelector: '.anim-teen .char img',
+  },
+  kid: {
+    label:      'KID',
+    sub:        'Profil 2 · Aktiv',
+    accentColor: '#7a9a00',
+    ringColor:   '#C3DB33',
+    badgeBg:     '#C3DB33',
+    charSelector: '.anim-kid .char img',
+  },
+};
+
+/* ═══════════════════════════════════════════════════════════════
+   STATE
+═══════════════════════════════════════════════════════════════ */
+let pinBuffer  = '';
+let wrongTries = 0;
+let currentScreen = 'screen-home';
+
+/* ═══════════════════════════════════════════════════════════════
+   CONFETTI
+═══════════════════════════════════════════════════════════════ */
+function createCandy(container) {
+  const el      = document.createElement('div');
+  const color   = CANDY_COLORS[Math.floor(Math.random() * CANDY_COLORS.length)];
+  const shape   = CANDY_SHAPES[Math.floor(Math.random() * CANDY_SHAPES.length)];
+  const size    = (Math.random() * 0.7 + 0.4);
+  const left    = Math.random() * 100;
+  const delay   = Math.random() * 6;
+  const dur     = Math.random() * 4 + 4;
+  const wobDur  = Math.random() * 1.5 + 1.5;
+  const wobX    = (Math.random() * 2 - 1).toFixed(1);
+  const r0      = Math.floor(Math.random() * 360);
+  const r1      = r0 + Math.floor(Math.random() * 720 - 360);
+
+  el.style.cssText = [
+    `position:absolute`,
+    `left:${left}%`,
+    `top:${-(size + 1)}cqw`,
+    `background:${color}`,
+    `--r0:${r0}deg`,
+    `--r1:${r1}deg`,
+    `--sx:1`,
+    `--wx:${wobX}cqw`,
+    `animation:fall ${dur}s ${delay}s linear infinite,wobble ${wobDur}s ${delay}s ease-in-out infinite`,
+  ].join(';');
+
+  switch (shape) {
+    case 'pill-h':
+      el.style.width = `${size * 2.2}cqw`; el.style.height = `${size}cqw`;
+      el.style.borderRadius = '50px'; break;
+    case 'pill-v':
+      el.style.width = `${size}cqw`; el.style.height = `${size * 2.2}cqw`;
+      el.style.borderRadius = '50px'; break;
+    case 'dot':
+      el.style.width = `${size * 0.9}cqw`; el.style.height = `${size * 0.9}cqw`;
+      el.style.borderRadius = '50%'; break;
+    case 'square':
+      el.style.width = `${size}cqw`; el.style.height = `${size}cqw`;
+      el.style.borderRadius = '2px'; break;
+  }
+
+  container.appendChild(el);
+}
+
+function initConfetti(containerId, count = 32) {
+  const container = document.getElementById(containerId);
+  if (!container) return;
+  for (let i = 0; i < count; i++) createCandy(container);
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   NAVIGATION
+═══════════════════════════════════════════════════════════════ */
+function navigate(fromId, toId, opts = {}) {
+  const fromEl = document.getElementById(fromId);
+  const toEl   = document.getElementById(toId);
+  if (!fromEl || !toEl) return;
+  fromEl.classList.add(opts.slideUp ? 'slide-out-up' : 'hidden');
+  toEl.classList.remove('hidden', 'slide-out-up');
+  currentScreen = toId;
+}
+
+function goHome() {
+  const curEl  = document.getElementById(currentScreen);
+  const homeEl = document.getElementById('screen-home');
+  if (curEl)  curEl.classList.add('hidden');
+  if (homeEl) homeEl.classList.remove('hidden', 'slide-out-up');
+  currentScreen = 'screen-home';
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   PIN
+═══════════════════════════════════════════════════════════════ */
+function updatePinDots() {
+  document.getElementById('pin-error')?.classList.remove('visible');
+  for (let i = 0; i < 4; i++) {
+    document.getElementById(`pd${i}`)?.classList.toggle('filled', i < pinBuffer.length);
+  }
+}
+
+function pinPress(key) {
+  if (key === 'del') {
+    pinBuffer = pinBuffer.slice(0, -1);
+    updatePinDots();
+    return;
+  }
+
+  if (key === 'ok') {
+    if (pinBuffer === CORRECT_PIN) {
+      // Correct — go to parental dashboard
+      navigate('screen-pin', 'screen-parental');
+      pinBuffer  = '';
+      wrongTries = 0;
+      setTimeout(updatePinDots, 400);
+      const hint = document.getElementById('pin-hint');
+      if (hint) hint.style.display = 'none';
+      document.getElementById('pin-error')?.classList.remove('visible');
+    } else {
+      // Wrong
+      wrongTries++;
+      const dots = document.getElementById('pin-dots');
+      dots?.classList.add('error');
+      document.getElementById('pin-error')?.classList.add('visible');
+      setTimeout(() => dots?.classList.remove('error'), 500);
+      pinBuffer = '';
+      updatePinDots();
+      if (wrongTries >= 2) {
+        const hint = document.getElementById('pin-hint');
+        if (hint) hint.style.display = 'block';
+      }
+    }
+    return;
+  }
+
+  if (pinBuffer.length < 4) {
+    pinBuffer += key;
+    updatePinDots();
+    if (pinBuffer.length === 4) setTimeout(() => pinPress('ok'), 200);
+  }
+}
+
+function showPin() {
+  pinBuffer = '';
+  updatePinDots();
+  navigate('screen-home', 'screen-pin');
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   PROFILE SELECTION
+═══════════════════════════════════════════════════════════════ */
+function selectProfile(type) {
+  const p = PROFILES[type];
+  if (!p) return;
+
+  // Update profile screen elements
+  const nameEl  = document.getElementById('profile-name');
+  const tagEl   = document.getElementById('profile-tag');
+  const bgEl    = document.getElementById('profile-char-bg');
+  const ringEl  = document.getElementById('profile-ring');
+  const badgeEl = document.getElementById('profile-badge');
+  const charEl  = document.getElementById('profile-char-img');
+  const subEl   = document.getElementById('profile-sub');
+
+  if (nameEl)  { nameEl.textContent = p.label; nameEl.style.color = p.accentColor; }
+  if (tagEl)   tagEl.textContent = p.label;
+  if (bgEl)    bgEl.style.background = p.ringColor;
+  if (ringEl)  ringEl.style.borderColor = p.ringColor;
+  if (badgeEl) badgeEl.style.background = p.badgeBg;
+  if (subEl)   subEl.textContent = p.sub;
+
+  // Copy character image src from home screen
+  const srcEl = document.querySelector(`#screen-home ${p.charSelector}`);
+  if (srcEl && charEl) charEl.src = srcEl.src;
+
+  navigate('screen-home', 'screen-profile', { slideUp: true });
+  setTimeout(() => launchCelebration(p.ringColor), 300);
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   CELEBRATION CONFETTI BURST (canvas)
+═══════════════════════════════════════════════════════════════ */
+function launchCelebration(accentColor) {
+  const canvas = document.getElementById('celebrate-canvas');
+  const scene  = canvas?.closest('.scene');
+  if (!canvas || !scene) return;
+
+  canvas.width  = scene.clientWidth;
+  canvas.height = scene.clientHeight;
+  const ctx = canvas.getContext('2d');
+
+  const colors = [accentColor, '#FC7107', '#16B7C9', '#FCD30B', '#8B2FC9', '#ffffff'];
+  const cx = canvas.width / 2;
+  const cy = canvas.height * 0.42;
+
+  const particles = Array.from({ length: 80 }, () => {
+    const angle = Math.random() * Math.PI * 2;
+    const speed = Math.random() * 8 + 4;
+    return {
+      x: cx, y: cy,
+      vx: Math.cos(angle) * speed,
+      vy: Math.sin(angle) * speed - Math.random() * 4,
+      color:   colors[Math.floor(Math.random() * colors.length)],
+      size:    Math.random() * 6 + 2,
+      gravity: 0.25,
+      alpha:   1,
+      rot:     Math.random() * 360,
+      rotV:    Math.random() * 8 - 4,
+      type:    Math.random() > 0.5 ? 'rect' : 'circle',
+      w:       Math.random() * 8 + 3,
+      h:       Math.random() * 4 + 2,
+    };
+  });
+
+  let rafId;
+  function draw() {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    let alive = 0;
+    for (const p of particles) {
+      if (p.alpha <= 0) continue;
+      alive++;
+      p.x += p.vx; p.y += p.vy; p.vy += p.gravity;
+      p.vx *= 0.99; p.rot += p.rotV;
+      p.alpha = Math.max(0, p.alpha - 0.012);
+      ctx.save();
+      ctx.globalAlpha = p.alpha;
+      ctx.fillStyle   = p.color;
+      ctx.translate(p.x, p.y);
+      ctx.rotate((p.rot * Math.PI) / 180);
+      if (p.type === 'circle') {
+        ctx.beginPath();
+        ctx.arc(0, 0, p.size, 0, Math.PI * 2);
+        ctx.fill();
+      } else {
+        ctx.fillRect(-p.w / 2, -p.h / 2, p.w, p.h);
+      }
+      ctx.restore();
+    }
+    if (alive > 0) rafId = requestAnimationFrame(draw);
+  }
+
+  draw();
+  setTimeout(() => {
+    cancelAnimationFrame(rafId);
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+  }, 3000);
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   PARENTAL TOGGLES
+═══════════════════════════════════════════════════════════════ */
+function toggleSwitch(id) {
+  document.getElementById(id)?.classList.toggle('on');
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   INIT
+═══════════════════════════════════════════════════════════════ */
+document.addEventListener('DOMContentLoaded', () => {
+  initConfetti('confetti-home', 32);
+});
+
+/* ── Expose to inline onclick handlers ── */
+Object.assign(window, {
+  showPin,
+  goHome,
+  pinPress,
+  selectProfile,
+  toggleSwitch,
+});

--- a/Goofy_design2/bundle/manifest.json
+++ b/Goofy_design2/bundle/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "PAN1K KnApPen!!!",
+  "short_name": "KnApPen",
+  "description": "Profilväljare för barn och tonåringar med föräldrakontroll",
+  "start_url": "/",
+  "display": "standalone",
+  "orientation": "portrait",
+  "background_color": "#0a0a14",
+  "theme_color": "#16B7C9",
+  "lang": "sv",
+  "categories": ["kids", "entertainment", "utilities"],
+  "icons": [
+    {
+      "src": "assets/image9.png",
+      "sizes": "any",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/Goofy_design2/bundle/package.json
+++ b/Goofy_design2/bundle/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "panik-knappen",
+  "version": "1.0.0",
+  "description": "PAN1K KnApPen!!! — mobilapp-UI profilväljare, PWA",
+  "private": true,
+  "scripts": {
+    "start":   "npx serve . --listen 8080",
+    "dev":     "npx serve . --listen 8080",
+    "preview": "npx serve . --listen 3000"
+  },
+  "keywords": ["pwa", "kids", "profile-selector", "swedish"],
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/Goofy_design2/bundle/service-worker.js
+++ b/Goofy_design2/bundle/service-worker.js
@@ -1,0 +1,70 @@
+/**
+ * PAN1K KnApPen!!! — service-worker.js
+ * Cache-first strategy: all assets cached on install, served offline.
+ * Update: bump CACHE_VERSION to invalidate on deploy.
+ */
+
+const CACHE_VERSION = 'panik-v1.0.0';
+const CACHE_NAME    = `panik-knappen-${CACHE_VERSION}`;
+
+const PRECACHE_URLS = [
+  '/',
+  '/index.html',
+  '/css/main.css',
+  '/js/app.js',
+  '/manifest.json',
+  '/assets/image1.png',
+  '/assets/image2.png',
+  '/assets/image3.png',
+  '/assets/image4.png',
+  '/assets/image5.png',
+  '/assets/image6.png',
+  '/assets/image7.png',
+  '/assets/image8.png',
+  '/assets/image9.png',
+  '/assets/image10.png',
+  '/assets/image11.png',
+  'https://fonts.googleapis.com/css2?family=Fredoka+One&family=Nunito:wght@700;800;900&display=swap',
+];
+
+/* ── Install: cache all assets ── */
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME)
+      .then(cache => cache.addAll(PRECACHE_URLS))
+      .then(() => self.skipWaiting())
+  );
+});
+
+/* ── Activate: remove old caches ── */
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys()
+      .then(keys => Promise.all(
+        keys
+          .filter(k => k.startsWith('panik-knappen-') && k !== CACHE_NAME)
+          .map(k  => caches.delete(k))
+      ))
+      .then(() => self.clients.claim())
+  );
+});
+
+/* ── Fetch: cache-first, fallback to network ── */
+self.addEventListener('fetch', event => {
+  // Skip non-GET and cross-origin requests (except Google Fonts)
+  if (event.request.method !== 'GET') return;
+
+  event.respondWith(
+    caches.match(event.request).then(cached => {
+      if (cached) return cached;
+      return fetch(event.request).then(response => {
+        // Cache successful responses
+        if (response && response.status === 200) {
+          const clone = response.clone();
+          caches.open(CACHE_NAME).then(cache => cache.put(event.request, clone));
+        }
+        return response;
+      });
+    })
+  );
+});

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Det här dokumentet är skrivet för dig som vill **bygga, testa och publicera a
 > Uppdatera den här sektionen varje gång du/agenten gör ändringar.
 
 ### Tidigare utförda aktiviteter
+- PR-fix klar (2026-03-11): `Goofy_design2/bundle/assets/*.png` är borttagna från git för att undvika larm om binärfiler i ändringsförslag, med ny lokal instruktion för att packa upp bilderna vid behov.
 - Repo-städning klar (2026-02-25): inaktiva filer/mappar är borttagna för enklare översikt, och `.gitignore` är tillagd så nya lokala beroendefiler (`node_modules`) inte stör översikten i status.
 - Dokumentation uppdaterad (2026-02-24): lagt till snabblänkar till Android-workflow och runs-sida högst upp i README för snabb felsökning.
 - Android-byggflöde förbättrat (2026-02-24): nytt script `npm run android:apk` kör webbsync + APK-build och ger tydligt felmeddelande om Android SDK saknas.
@@ -97,6 +98,7 @@ Det här dokumentet är skrivet för dig som vill **bygga, testa och publicera a
 3. Visa backend-logg för snabbåtgärder i egen vy i familjeläget.
 
 ### Pågående aktivitet (nu)
+- Säkerställa att designbundle kan delas utan binärfils-larm i PR och att lokala återställningssteg för bilder är tydligt dokumenterade.
 - Verifiera nästa online-deploy efter repo-städning och bekräfta att barn/familj-undersidorna laddar korrekt.
 - Planera ny, stabil återaktivering av föräldrakod (utan hårdkodad testkod) efter verifierat låsflöde.
 - Bryta ut native-MVP (första fungerande mobilversion) med overlay-behörighet i Android och samma API-flöde som webbappen.


### PR DESCRIPTION
### Motivation
- Provide a self-contained design bundle that reproduces the PAN1K profile-selector UI as a static PWA for review and local testing.
- Keep binary image assets out of the PR while allowing contributors to rehydrate them locally via a documented unzip step.
- Add a lightweight offline-capable prototype (no build step) that demonstrates navigation, PIN flow and celebration animations.

### Description
- Adds a new bundle under `Goofy_design2/bundle` containing a complete static PWA prototype with `index.html`, `css/main.css`, `js/app.js`, `manifest.json`, `service-worker.js`, and `package.json`. 
- Adds repository docs and agent context files: `bundle/README.md`, `bundle/agents.md`, and `bundle/assets/README-assets.md`, and keeps `assets/` empty in git with `assets/.gitkeep` and instructions for restoring PNGs locally. 
- Adds `bundle/.gitignore` to ignore platform/editor files and binary assets (`assets/*.png`) and updates the top-level `README.md` to note that image assets are intentionally omitted and how to restore them. 
- Implements UI behavior in `js/app.js` including navigation, a 4-digit PIN (`CORRECT_PIN = '1234'`), confetti/candy particle layers, profile selection, parental toggles, and a cache-first `service-worker.js` pre-cache list for offline use. 

### Testing
- No automated test suite was executed as part of this change (no CI tests were run). 
- A Playwright snapshot example for local automated screenshot testing is provided in `bundle/agents.md` for teams who want to add automated visual tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0eabfa4dc8328b1e701aed9c54193)