### PR TITLE
Lägg till verifieringsscript för visuella referenser och uppdatera README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Det här dokumentet är skrivet för dig som vill **bygga, testa och publicera a
 > Uppdatera den här sektionen varje gång du/agenten gör ändringar.
 
 ### Tidigare utförda aktiviteter
+- Granskning + felsökning klar (2026-03-11): ny verifieringscheck `node scripts/verify-goofy-design2.js` jämför aktiva appens skärmar/deployfiler mot `Screenshots_for_visual_verification_goofydesign2/VISUAL-REFERENCE.md` och säkerställer att alla 10 referensbilder + grid finns i repo.
+- Deploystatus verifierad (2026-03-11): `./scripts/netlify-deploy.sh preview` stoppar korrekt i non-interactive miljö när `NETLIFY_AUTH_TOKEN` saknas; blockeraren är nu bekräftad och samma körning visar att publiceringsmappen är `Goofy_design2/bundle`.
 - Netlify-konfiguration uppdaterad (2026-03-11): `scripts/netlify-deploy.sh` har nu färdiga lägen `hook-preview`, `hook-preview-2` och `hook-prod` för de sparade Netlify-hookarna, och preview-hook triggas verifierat från repo-roten.
 - Appbyte klart (2026-03-11): tidigare aktiva `panik-overlay/` är arkiverad till `archive/panik-overlay-legacy/`, och ny aktiv app är nu `Goofy_design2/bundle/` för lokal körning och deploy (publicering).
 - PR-fix klar (2026-03-11): `Goofy_design2/bundle/assets/*.png` är borttagna från git för att undvika larm om binärfiler i ändringsförslag, med ny lokal instruktion för att packa upp bilderna vid behov.
@@ -99,6 +101,7 @@ Det här dokumentet är skrivet för dig som vill **bygga, testa och publicera a
 3. Visa backend-logg för snabbåtgärder i egen vy i familjeläget.
 
 ### Pågående aktivitet (nu)
+- Jämföra nya lokala snapshots mot referensbilderna (`Screenshots_for_visual_verification_goofydesign2/`) så fort browserverktyget är stabilt igen.
 - Säkerställa att designbundle kan delas utan binärfils-larm i PR och att lokala återställningssteg för bilder är tydligt dokumenterade.
 - Verifiera nästa online-deploy efter repo-städning och bekräfta att barn/familj-undersidorna laddar korrekt.
 - Planera ny, stabil återaktivering av föräldrakod (utan hårdkodad testkod) efter verifierat låsflöde.

--- a/scripts/verify-goofy-design2.js
+++ b/scripts/verify-goofy-design2.js
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+
+function read(file) {
+  return fs.readFileSync(path.join(root, file), 'utf8');
+}
+
+function exists(file) {
+  return fs.existsSync(path.join(root, file));
+}
+
+const failures = [];
+const passes = [];
+
+function check(condition, okText, failText) {
+  if (condition) {
+    passes.push(okText);
+  } else {
+    failures.push(failText);
+  }
+}
+
+const visualDocPath = 'Screenshots_for_visual_verification_goofydesign2/VISUAL-REFERENCE.md';
+check(exists(visualDocPath), 'VISUAL-REFERENCE finns.', 'Saknar VISUAL-REFERENCE.md.');
+
+if (exists(visualDocPath)) {
+  const visualDoc = read(visualDocPath);
+  const expectedRefs = [
+    '01-home.png',
+    '02-home-teen-hover.png',
+    '03-pin-empty.png',
+    '04-pin-partial.png',
+    '05-pin-error.png',
+    '06-parental-dashboard.png',
+    '07-parental-toggle.png',
+    '08-profile-teen.png',
+    '09-profile-kid.png',
+    '10-home-1080x1920.png',
+    '00-verification-grid.png',
+  ];
+
+  expectedRefs.forEach((name) => {
+    const rel = `Screenshots_for_visual_verification_goofydesign2/${name}`;
+    check(exists(rel), `${name} finns i referensmappen.`, `Saknar referensbild: ${name}`);
+  });
+
+  check(
+    visualDoc.includes('Skärm 1 — Profilväljare') &&
+      visualDoc.includes('Skärm 2 — PIN-pad') &&
+      visualDoc.includes('Skärm 3 — Profil aktiv') &&
+      visualDoc.includes('Skärm 4 — Föräldrakontroll'),
+    'VISUAL-REFERENCE beskriver alla 4 skärmar.',
+    'VISUAL-REFERENCE saknar någon kritisk skärmbeskrivning.'
+  );
+}
+
+const indexHtmlPath = 'Goofy_design2/bundle/index.html';
+check(exists(indexHtmlPath), 'index.html finns.', 'Saknar Goofy_design2/bundle/index.html.');
+
+if (exists(indexHtmlPath)) {
+  const html = read(indexHtmlPath);
+  ['screen-home', 'screen-pin', 'screen-profile', 'screen-parental'].forEach((id) => {
+    check(html.includes(`id="${id}"`), `${id} finns i index.html.`, `Saknar ${id} i index.html.`);
+  });
+
+  ['Välj TEEN-profil', 'Välj KID-profil', 'Föräldraåtkomst'].forEach((label) => {
+    check(html.includes(label), `Knappetikett "${label}" finns.`, `Saknar knappetikett "${label}".`);
+  });
+}
+
+const appJsPath = 'Goofy_design2/bundle/js/app.js';
+check(exists(appJsPath), 'app.js finns.', 'Saknar Goofy_design2/bundle/js/app.js.');
+if (exists(appJsPath)) {
+  const js = read(appJsPath);
+  ['const CORRECT_PIN = \'1234\'', 'function showPin()', 'function selectProfile(type)'].forEach((needle) => {
+    check(js.includes(needle), `Hittade "${needle}" i app.js.`, `Saknar "${needle}" i app.js.`);
+  });
+}
+
+const netlifyTomlPath = 'netlify.toml';
+check(exists(netlifyTomlPath), 'netlify.toml finns.', 'Saknar netlify.toml.');
+if (exists(netlifyTomlPath)) {
+  const netlify = read(netlifyTomlPath);
+  check(
+    netlify.includes('publish = "Goofy_design2/bundle"'),
+    'netlify.toml publish pekar till Goofy_design2/bundle.',
+    'netlify.toml publish pekar inte till Goofy_design2/bundle.'
+  );
+}
+
+const deployScriptPath = 'scripts/netlify-deploy.sh';
+check(exists(deployScriptPath), 'Deploy-script finns.', 'Saknar scripts/netlify-deploy.sh.');
+if (exists(deployScriptPath)) {
+  const script = read(deployScriptPath);
+  check(
+    script.includes('PUBLISH_DIR="$ROOT_DIR/Goofy_design2/bundle"'),
+    'Deploy-script publicerar Goofy_design2/bundle.',
+    'Deploy-script publicerar inte Goofy_design2/bundle.'
+  );
+}
+
+console.log('--- Verifieringsresultat: Goofy design + deploy ---');
+passes.forEach((line) => console.log(`✅ ${line}`));
+
+if (failures.length > 0) {
+  failures.forEach((line) => console.error(`❌ ${line}`));
+  process.exit(1);
+}
+
+console.log('Totalt OK:', passes.length, 'kontroller.');


### PR DESCRIPTION
### Motivation
- Göra en enkel, repeterbar kontroll att den aktiva bundle-appen matchar visuella referenserna (screenshots) och att deploy-konfigurationen pekar rätt. 
- Förenkla felsökning av deploy (Netlify) i non-interactive miljö genom att dokumentera varför preview-deploy stoppar utan token. 

### Description
- Lagt till `scripts/verify-goofy-design2.js` som körs med Node och kontrollerar att `Screenshots_for_visual_verification_goofydesign2/VISUAL-REFERENCE.md`, alla referensbilder (00–10), viktiga skärm-id:n i `Goofy_design2/bundle/index.html`, `js/app.js`-nyckelsträngar samt `netlify.toml` och `scripts/netlify-deploy.sh` finns och pekar mot `Goofy_design2/bundle` (publiceringsmappen). 
- Uppdaterat README-statusloggen med resultat från granskningen/felsökningen och med en pågående punkt om att jämföra snapshots mot referenser när browserverktyget är stabilt igen. 
- Scriptet är körbart (`chmod +x`) och gjort så att det är enkelt att återköra verifieringen lokalt (ingen installation utöver Node behövs för själva checken). 

### Testing
- Kör i repo-roten: `node scripts/verify-goofy-design2.js` — lyckades och rapporterade alla förväntade kontroller som OK. 
- Kör i `Goofy_design2/bundle`: `npm run check` — lyckades och bekräftade bundle-struktur (filer `index.html`, `css/main.css`, `js/app.js`, `service-worker.js`, `manifest.json`). 
- Kör i repo-roten: `./scripts/netlify-deploy.sh preview` — stoppade som förväntat i non-interactive miljö eftersom `NETLIFY_AUTH_TOKEN` saknas (blockerare bekräftad). 
- Automatisk visuell snapshot-körning med Playwright misslyckades p.g.a. browser-processkrasch i verktygsmiljön (SIGSEGV), så inga nya snapshots togs i denna körning. 

Kör gärna dessa copy/paste-kommandon i repo-roten (projektmapp på GitHub):
```
node scripts/verify-goofy-design2.js
cd Goofy_design2/bundle && npm run check
./scripts/netlify-deploy.sh preview
```
Nästa enklaste steg för dig är att sätta `NETLIFY_AUTH_TOKEN` + `NETLIFY_SITE_ID` i din miljö och köra `./scripts/netlify-deploy.sh preview` i repo-roten så vi kan verifiera live-deploy (publicering) och ta nya snapshots när browserverktyget är stabilt.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1038140808328a2f8bd0a1ada0d02)